### PR TITLE
readme-alignment: scrub "Lab", retitle READMEs, add scripts/ + weather-api READMEs, TOC §4.3 ACA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ deploy-vars*.sh
 .idea/
 
 *.log
+
+# Local PR scratchpads
+PR-*-DESCRIPTION.md

--- a/GA-CONTENT-TOC.md
+++ b/GA-CONTENT-TOC.md
@@ -22,6 +22,7 @@ microsoft/entra-agentid-samples/
 │   └── CODEOWNERS
 │
 ├── scripts/
+│   ├── README.md                          ← PowerShell bootstrap walkthrough (ties to §1.2)
 │   └── EntraAgentID-Functions.ps1         ← Shared PowerShell tooling
 │
 ├── sidecar/                               ← SIDECAR PATTERN (container-based)
@@ -76,6 +77,10 @@ microsoft/entra-agentid-samples/
     │   │   ├── docker-compose.app-service.yml
     │   │   ├── infra/app-service.bicep
     │   │   └── deploy.sh
+    │   │
+    │   ├── container-apps/                ← Azure Container Apps (zero-secret, federated)
+    │   │   ├── aws/README.md              ← AWS Bedrock agent + sidecar on ACA
+    │   │   └── dev/README.md              ← Local-LLM (Ollama) agent + sidecar on ACA
     │   │
     │   └── aks/                           ← AKS + Workload Identity
     │       ├── README.md
@@ -134,6 +139,7 @@ microsoft/entra-agentid-samples/
 |---|---|---|
 | 4.1 | Deploy to Azure App Service | Razi ([@razi-rais](https://github.com/razi-rais)) |
 | 4.2 | Deploy to Azure Kubernetes Service with Workload Identity | Yoel ([@yoelhor](https://github.com/yoelhor)) |
+| 4.3 | Deploy to Azure Container Apps | Razi ([@razi-rais](https://github.com/razi-rais)) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # Entra Agent ID Samples
+
+Runnable samples and walkthroughs for **Microsoft Entra Agent ID** — Entra's purpose-built identity for AI agents.
+
+This repository shows you how to:
+
+- Provision a **Blueprint** application, an **Agent Identity**, and a **Client SPA** in your Entra tenant.
+- Run the **Microsoft Entra SDK auth sidecar** next to your agent so the agent code never sees a secret.
+- Mint **autonomous (app-only)** and **on-behalf-of** tokens for the agent.
+- Call a downstream API (the included `weather-api`) with a token that validates cleanly (signature, issuer, agent-identity claims).
+- Deploy the whole thing to **Azure Container Apps** with *zero stored secrets* — federated credentials only.
+
+## Start here
+
+| If you're… | Go to |
+|---|---|
+| New to Entra Agent ID and want the concepts | [`sidecar/README.md`](sidecar/README.md) — the sidecar design pattern |
+| Setting up your Entra tenant for the first time | [`scripts/README.md`](scripts/README.md) — PowerShell bootstrap walkthrough |
+| Looking for the fastest runnable demo | [`sidecar/dev/README.md`](sidecar/dev/README.md) — local agent with Ollama |
+| Running against a cloud LLM | [`sidecar/aws/README.md`](sidecar/aws/README.md) — AWS Bedrock (Claude) |
+| Deploying to Azure | [`deploy/azure/container-apps/`](deploy/azure/container-apps/) |
+
+## Table of contents
+
+Content is laid out per [`GA-CONTENT-TOC.md`](GA-CONTENT-TOC.md).
+
+### 1 · Getting started
+- **1.1** Entra Agent ID architecture and patterns *(coming soon — owner @astaykov)*
+- **1.2** [`PREREQUISITES.md`](PREREQUISITES.md) — environment setup *(coming soon — owner @Gargi-Sinha)*
+
+### 2 · Sidecar pattern
+- **2.1** [The Sidecar Design Pattern](sidecar/README.md)
+- **2.2** End-to-end token flow: agent → weather API *(covered inline in §2.3 sample)*
+- **2.3** [Run the sidecar locally (developer quickstart)](sidecar/dev/README.md)
+
+### 3 · Third-party agent platforms
+
+Sidecar pattern (container-based):
+- **3.1** [AWS: Amazon Bedrock agent with Entra Agent ID sidecar](sidecar/aws/README.md)
+- **3.2** GCP: Vertex AI (Gemini) agent with Entra Agent ID sidecar *(coming soon)*
+
+Federation pattern (token exchange via FIC):
+- **3.3** GCP: Workload Identity Federation with Entra Agent ID *(coming soon — owner @ArLucaID)*
+
+Low-code:
+- **3.5** N8N: low-code agent with Entra Agent ID *(coming soon — owner @astaykov)*
+
+### 4 · Deploy
+- **4.1** Deploy to Azure App Service *(coming soon)*
+- **4.2** Deploy to Azure Kubernetes Service with Workload Identity *(coming soon — owner @yoelhor)*
+- **4.3** [Deploy to Azure Container Apps](deploy/azure/container-apps/) — AWS Bedrock and local-LLM variants
+
+## Repository layout
+
+```
+├── scripts/                   Shared PowerShell + bash bootstrap tooling
+├── sidecar/                   Sidecar pattern samples
+│   ├── weather-api/           Shared token-validated downstream API
+│   ├── dev/                   Local-LLM (Ollama) edition
+│   └── aws/                   AWS Bedrock edition
+├── deploy/                    Deployment samples
+│   └── azure/container-apps/  Azure Container Apps tutorials
+└── .github/skills/            AI-led workflow skills (optional tooling)
+```
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) *(coming soon)*. Content owners are listed in [`GA-CONTENT-TOC.md`](GA-CONTENT-TOC.md).
+
+Branching model: `owner/feature → PR → dev → PR → main`.
+
+## License and code of conduct
+
+- [`LICENSE`](LICENSE)
+- [`SECURITY.md`](SECURITY.md)
+- Code of Conduct: this project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,225 @@
+# Scripts — Entra Agent ID Bootstrap
+
+Shared PowerShell and bash tooling that provisions the Entra objects every sample in this repo depends on:
+
+- a **Blueprint application** with a client credential
+- an **Agent Identity** with Microsoft Graph `User.Read.All` granted
+- a **Client SPA** for the On-Behalf-Of (OBO) flow
+- OAuth2 permission grants wiring the three together
+
+Run these once per tenant. After that, the IDs go into each sample's `.env` (local dev) or into federated credentials (Azure production).
+
+> TOC: these scripts back **§1.2 Prerequisites** and are referenced from the §2 and §3 samples. For the conceptual overview see [`../sidecar/README.md`](../sidecar/README.md).
+
+## Prerequisites
+
+- **PowerShell 7.4+** (`pwsh`) on macOS, Linux, or Windows. The workflow uses `Microsoft.Graph.*` modules 2.35+.
+- **Entra role** on the user signing in — one of:
+  - `Global Administrator`
+  - `Agent ID Administrator` (template `db506228-d27e-4b7d-95e5-295956d6615f`) — recommended
+  - `Agent ID Developer` (template `adb2368d-a9be-41b5-8667-d96778e081b0`) — least privilege
+- **Graph modules:** `Install-Module Microsoft.Graph -Scope CurrentUser`
+
+## Files in this folder
+
+| File | Purpose |
+|---|---|
+| [`EntraAgentID-Functions.ps1`](EntraAgentID-Functions.ps1) | The main module. Exposes `Start-EntraAgentIDWorkflow` plus a set of lower-level helpers. |
+| [`setup-obo-blueprint.ps1`](setup-obo-blueprint.ps1) | Adds the `access_as_user` scope to a Blueprint and grants a Client SPA permission against it. PowerShell edition. |
+| [`setup-obo-blueprint.sh`](setup-obo-blueprint.sh) | Same workflow in bash, for CI systems without PowerShell. |
+| [`setup-obo-client-app.sh`](setup-obo-client-app.sh) | Creates the Client SPA if one doesn't already exist in the tenant. |
+
+## One-shot bootstrap
+
+```powershell
+# From the repo root
+cd scripts
+. ./EntraAgentID-Functions.ps1
+Start-EntraAgentIDWorkflow
+```
+
+This interactively creates a Blueprint, mints an Agent Identity, and grants the Agent `User.Read.All`. You'll see output like:
+
+```
+Blueprint App ID:     <your-blueprint-app-id>
+Blueprint Secret:     <generated>
+Agent App ID:         <your-agent-app-id>
+Agent Permissions:    User.Read.All (granted)
+```
+
+Save these values — you'll paste them into each sample's `.env` next.
+
+## Walkthrough: end-to-end verification
+
+This section proves the bootstrap worked by running the sidecar against a freshly created Agent Identity and calling Microsoft Graph with the minted token. It assumes you completed the one-shot bootstrap above.
+
+### You'll learn
+
+- How the Blueprint credential is consumed by the sidecar (not your agent code).
+- What a two-token exchange (T1 → T2) looks like on the wire.
+- How to inspect the Agent token's claims and confirm `User.Read.All` is present.
+- The difference between the `/AuthorizationHeader` (token-only) and `/DownstreamApi` (token + proxied call) sidecar endpoints.
+
+### Step 1 — Prepare environment configuration
+
+```powershell
+# In the repo root
+cd sidecar/dev          # or sidecar/aws
+Copy-Item .env.example .env
+```
+
+### Step 2 — Paste the bootstrap values into `.env`
+
+```
+TENANT_ID=<your-tenant-id>
+BLUEPRINT_APP_ID=<blueprint-app-id from Step 1>
+BLUEPRINT_CLIENT_SECRET=<secret from Start-EntraAgentIDWorkflow>
+AGENT_CLIENT_ID=<agent-app-id from Step 1>
+```
+
+> For production on Azure App Service / Container Apps, **do not set `BLUEPRINT_CLIENT_SECRET`**. Use `SourceType=SignedAssertionFromManagedIdentity` instead. See [`../deploy/azure/container-apps/`](../deploy/azure/container-apps/).
+
+### Step 3 — Start the sidecar
+
+```powershell
+docker-compose up -d sidecar
+# For dev edition, also bring up Ollama and the agent; for aws, also the agent + token-refresher
+```
+
+Verify it's healthy:
+
+```powershell
+Invoke-RestMethod http://localhost:5000/health
+```
+
+### Step 4 — Get an Agent Identity token
+
+```powershell
+$agentAppId = "<your-agent-app-id>"
+
+$response = Invoke-RestMethod `
+  -Uri "http://localhost:5000/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId" `
+  -Method GET
+
+$token = $response.authorizationHeader   # "Bearer eyJ..."
+Write-Host "Got agent token: $($token.Substring(0,50))..."
+```
+
+What just happened:
+
+1. You asked the sidecar for a Graph authorization header scoped to your Agent Identity.
+2. The sidecar used the Blueprint credential to get a Blueprint token (T1) from Entra.
+3. The sidecar exchanged T1 for an Agent token (T2) scoped to your Agent's permissions.
+4. You received `Bearer <T2>`.
+
+### Step 5 — Call Microsoft Graph with the Agent token
+
+```powershell
+$users = Invoke-RestMethod `
+  -Uri "https://graph.microsoft.com/v1.0/users" `
+  -Headers @{ Authorization = $token }
+
+$users.value | Select-Object displayName, userPrincipalName | Format-Table
+```
+
+If you get a list of users back, the Agent's `User.Read.All` grant is working end-to-end.
+
+### Step 6 — Verify the token claims (optional)
+
+```powershell
+$jwt = $token -replace "^Bearer ", ""
+$payload = $jwt.Split(".")[1]
+# Base64url decode and parse
+$padded = $payload.PadRight($payload.Length + ((4 - $payload.Length % 4) % 4), "=")
+$json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($padded.Replace("-", "+").Replace("_", "/")))
+$claims = $json | ConvertFrom-Json
+
+"App ID (appid):           $($claims.appid)"
+"Audience (aud):           $($claims.aud)"
+"Issuer (iss):             $($claims.iss)"
+"Roles:                    $($claims.roles -join ', ')"
+"Agent Identity marker:    xms_par_app_azp=$($claims.xms_par_app_azp)"
+```
+
+The key claim is `xms_par_app_azp` — it identifies the Blueprint that minted this token. That's how downstream APIs recognize the token as an Agent Identity token (and not a plain app-only token).
+
+### Step 7 — Simplified pattern: sidecar does the call for you
+
+Instead of two round-trips (get token, then call Graph), the sidecar can proxy the call:
+
+```powershell
+$result = Invoke-RestMethod `
+  -Uri "http://localhost:5000/DownstreamApiUnauthenticated/graph?optionsOverride.RelativePath=users&AgentIdentity=$agentAppId" `
+  -Method POST
+
+$users = ($result.content | ConvertFrom-Json).value
+$users | Select-Object displayName | Format-Table
+```
+
+Response shape: `{"statusCode": 200, "content": "<json string>"}`. The sidecar calls Graph for you and returns the response wrapped.
+
+## Endpoints reference
+
+| Endpoint | Authenticated? | Returns |
+|---|---|---|
+| `GET /AuthorizationHeader/graph` | Yes — requires incoming Bearer (OBO) | `Bearer <TF1>` (agent-on-behalf-of-user) |
+| `GET /AuthorizationHeaderUnauthenticated/graph` | No (app-only) | `Bearer <TR>` (autonomous agent) |
+| `POST /DownstreamApi/graph` | Yes (OBO) | `{statusCode, content}` from Graph |
+| `POST /DownstreamApiUnauthenticated/graph` | No (app-only) | `{statusCode, content}` from Graph |
+| `GET /health` | No | `Healthy` |
+
+Always use `-Method POST` when hitting the `/DownstreamApi*` endpoints even if the downstream verb is GET. This is a [known requirement](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/endpoints) of the SDK.
+
+## Troubleshooting
+
+### `Access token is empty`
+The Blueprint credential in `.env` is blank or placeholder. Re-run `Start-EntraAgentIDWorkflow` and paste the real `BLUEPRINT_APP_ID` + `BLUEPRINT_CLIENT_SECRET`.
+
+### `405 Method Not Allowed`
+You're calling `/DownstreamApi*` with `GET`. Use `-Method POST`.
+
+### Token has no `roles` claim
+Graph permissions weren't granted-and-consented. Run `Start-EntraAgentIDWorkflow` to completion — it calls `Add-MgServicePrincipalAppRoleAssignment` to grant the role.
+
+### `403 Authorization_RequestDenied` creating the Blueprint
+Your signing-in user lacks an Agent ID role. `Application Administrator` is **not** sufficient. Add `Agent ID Developer` or `Agent ID Administrator` to your user.
+
+### Container name conflict on restart
+```powershell
+docker-compose down
+docker ps -a | Select-String entra-sidecar | ForEach-Object { docker rm -f ($_ -split '\s+')[0] }
+docker-compose up -d
+```
+
+### Endpoint returns 404
+Your sidecar is older than `mcr.microsoft.com/entra-sdk/auth-sidecar:latest`. Pull the latest:
+```powershell
+docker pull mcr.microsoft.com/entra-sdk/auth-sidecar:latest
+docker-compose up -d --force-recreate sidecar
+```
+
+## Cleanup
+
+```powershell
+docker-compose down -v
+```
+
+To remove the Entra objects from your tenant:
+```powershell
+. ./EntraAgentID-Functions.ps1
+Remove-EntraAgentIDWorkflow -BlueprintAppId <blueprint-app-id> -AgentAppId <agent-app-id>
+```
+
+## Summary
+
+After completing this walkthrough you have:
+
+- a Blueprint and Agent Identity in your tenant, with `User.Read.All` granted to the Agent
+- a running sidecar that mints Agent tokens on demand, zero secrets in your own code
+- verified end-to-end: sidecar → Entra → Graph → real user data
+- the same `.env` values that the [`sidecar/dev`](../sidecar/dev/README.md) and [`sidecar/aws`](../sidecar/aws/README.md) samples consume
+
+Proceed to one of the full samples to see an LLM drive this flow against the `weather-api`:
+
+- [`sidecar/dev/README.md`](../sidecar/dev/README.md) — local-LLM (Ollama) + LangChain
+- [`sidecar/aws/README.md`](../sidecar/aws/README.md) — AWS Bedrock (Claude) + LangChain

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,1250 +1,143 @@
-# Lab Guide: Testing Microsoft Entra Agent Identity with Sidecar
+# The Sidecar Design Pattern
 
-> **📚 Learning Path:** This guide covers the **fundamentals** of Agent Identity tokens using simple PowerShell commands. Once you understand the basics, check out the [LLM Agent Demo](./llm-agent/README.md) for a complete end-to-end example with a chat UI, real weather API, and visual token flow.
+How the **Microsoft Entra Agent ID sidecar** lets an AI agent call downstream APIs with a secure, per-agent identity — without the agent code ever seeing a secret.
 
-## What This Lab Does
+This document is the conceptual overview (TOC §2.1). For runnable samples, see:
+- [`dev/`](dev/README.md) — local-LLM (Ollama) edition
+- [`aws/`](aws/README.md) — AWS Bedrock (Claude) edition
+- [`weather-api/`](weather-api/README.md) — shared downstream API used by both
 
-**Simple Scenario:** You have an AI agent that needs to read user data from your Entra tenant. This lab shows you how to use the Microsoft Entra sidecar to securely get an Agent Identity token, then use that token to call Microsoft Graph API and retrieve users. The sidecar manages all the credentials - your application just requests tokens.
+For the PowerShell bootstrap that creates the Entra objects used by every sample, see [`../scripts/README.md`](../scripts/README.md).
 
-## ⚠️ Prerequisites
+## The problem
 
-Before starting this guide, you **must** complete the setup in the [Main README](../README.md):
+Two common approaches to agent authentication both fall short:
 
-1. ✅ Create a Blueprint application
-2. ✅ Create a Blueprint service principal  
-3. ✅ Create an Agent Identity
-4. ✅ Assign permissions to your Agent
+1. **Hard-coded secrets in agent code.** Every agent image holds a copy of your app's `client_secret`. Any compromise, any log leak, any forgotten `.env` committed to Git is a full tenant breach.
+2. **Delegated user tokens for everything.** The agent is reduced to acting only when a human is present, and you lose individual auditability — every call looks like the same service principal.
 
-**👉 [Complete the Main README setup first](../README.md)** - This guide assumes you have a working Blueprint and Agent Identity.
+Entra Agent ID gives each agent its own identity. The sidecar pattern makes that identity easy to use.
 
-**What you'll do:**
-1. Deploy a sidecar container and configure it with your Blueprint credentials
-2. Request an Agent Identity token for your specific AI agent
-3. Call Microsoft Graph API to get users (proves your agent has the User.Read.All permission)
-4. Understand the two-token exchange (Blueprint → Agent Identity)
+## What the sidecar does
 
-**Estimated time:** 30 minutes
+The **[Microsoft Entra SDK auth sidecar](https://mcr.microsoft.com/en-us/product/entra-sdk/auth-sidecar/about)** (`mcr.microsoft.com/entra-sdk/auth-sidecar`) runs as a second container next to your agent. It exposes a small HTTP API on the pod-local network and handles:
 
----
+- Client-credentials exchange with `login.microsoftonline.com`
+- Blueprint → Agent Identity token exchange (T1 → T2)
+- On-Behalf-Of (OBO) flows for user-context calls
+- Token caching, refresh, and expiry
+- Credential source abstraction — `ClientSecret` for dev, `SignedAssertionFromManagedIdentity` for production, same API
 
-## Lab Objectives
+Your agent asks the sidecar *"give me an authorization header for this API"* and gets back `Bearer eyJ…`. Credentials never live in agent memory.
 
-By the end of this lab, you will:
-- ✅ Deploy and configure the Microsoft Entra Agent ID sidecar
-- ✅ Understand how two-token exchange works (Blueprint → Agent)
-- ✅ Acquire Agent Identity tokens for autonomous agents
-- ✅ Call Microsoft Graph API to retrieve users using Agent Identity
-- ✅ Verify the token contains the permissions you assigned
+| Agent (your code) | Sidecar (Microsoft Entra SDK) |
+|---|---|
+| Decide when to call the API | Acquire and cache the right token |
+| Build the HTTP request | Perform client-credentials and OBO exchange |
+| Pass through user token for OBO | Validate and forward user assertion |
+| Handle business logic | Talk to `login.microsoftonline.com` |
 
----
+The security boundary is explicit: the sidecar has no host port. Only services inside the same network (your agent, not your browser, not random processes on the host) can request tokens.
 
-## Why Agent Identity?
+## The identity objects
 
-Traditional approaches require storing secrets in your app code or need a human user to log in. Agent Identity provides a better way:
+| Object | Role | Where it lives |
+|---|---|---|
+| **Blueprint application** | Factory / template that issues Agent Identities. Holds the client credential (secret or federated). | Your Entra tenant |
+| **Agent Identity** | The individual AI agent. Has its own app ID, its own permission grants (e.g. `User.Read.All`), its own audit trail. | Your Entra tenant |
+| **Client SPA** (OBO only) | Web UI that signs the user in and exchanges the user's token into an Agent token on their behalf. | Your Entra tenant |
+| **Sidecar container** | Runs client-credentials and OBO flows. Knows the Blueprint credential. | Next to your agent |
+| **Agent container** | Your application code. Asks the sidecar for headers. | Your pod / compose / App Service |
 
-- **Individual identity for each AI agent** - Better audit trails
-- **Secrets managed by sidecar** - Your app never sees credentials
-- **Granular permissions per agent** - Each agent gets only what it needs
-- **No user login required** - Agents operate autonomously
+Provisioning is covered in [`../scripts/README.md`](../scripts/README.md) — the `Start-EntraAgentIDWorkflow` PowerShell cmdlet creates all three Entra objects in one shot.
 
----
+## Two token flows
 
-## What You'll Learn
+### Autonomous (app-only) — **TR**
 
-This lab demonstrates how to use the **Microsoft Entra SDK for Agent ID sidecar** - a containerized service that:
-- Handles token acquisition for Agent Identities (AI agents)
-- Performs secure two-token exchange (Blueprint → Agent)
-- Eliminates the need to manage secrets in your application code
-- Provides both token-only and full API proxy patterns
-
-**Use cases:**
-- Autonomous AI agents that need to access Microsoft 365 data
-- Third-party applications requiring delegated access
-- Secure service-to-service communication with Agent Identity
-
----
-
-## Architecture Overview
-
-### Complete Lab Flow
+The agent runs on its own schedule (cron, queue trigger, MCP request from another service). There is no user in the loop.
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                         COMPLETE ARCHITECTURE FLOW                              │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-PATTERN A: Get Token Only (Step 1 & 2)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-    ┌──────────────────────┐
-    │   Your App/Script    │
-    │   (PowerShell)       │
-    └──────────┬───────────┘
-               │
-               │ ① GET /AuthorizationHeaderUnauthenticated/graph
-               │    ?AgentIdentity=aaaa1111...
-               ↓
-    ┌─────────────────────────────────────────────────────────────────┐
-    │              Sidecar Container                                  │
-    │                                                                 │
-    │  Blueprint App ID: 03f6638f...                                  │
-    │  Blueprint Secret: ***                                          │
-    │                                                                 │
-    │  ② Two-Token Exchange (T1/T2):                                 │
-    │     ┌────────────────────────────────────────────────┐          │
-    │     │ • Request T1 with Blueprint credentials        │          │
-    │     │   (03f6638f... + secret)                       │          │
-    │     │              ↓                                 │          │
-    │     │   Microsoft Entra ID                           │          │
-    │     │              ↓                                 │          │
-    │     │ • Receive Blueprint Token (T1)                 │          │
-    │     │              ↓                                 │          │
-    │     │ • Exchange T1 → Agent Token (T2)               │          │
-    │     │   for Agent ID: aaaa1111...                    │          │
-    │     │   with scopes: User.Read.All                   │          │
-    │     │              ↓                                 │          │
-    │     │ • Receive Agent Token (T2)                     │          │
-    │     └────────────────────────────────────────────────┘          │
-    │                                                                 │
-    │  ③ Returns: {"authorizationHeader": "Bearer eyJ..."}           │
-    │                                                                 │
-    └──────────┬──────────────────────────────────────────────────────┘
-               │
-               │ ④ Token received
-               ↓
-    ┌──────────────────────┐
-    │   Your App/Script    │  $token = "Bearer eyJ..."
-    └──────────┬───────────┘
-               │
-               │ ⑤ Call API with token
-               │    GET https://graph.microsoft.com/v1.0/users
-               │    Authorization: Bearer eyJ...
-               ↓
-    ┌──────────────────────────────────────────────────────┐
-    │           Microsoft Graph API                        │
-    │  • Validates token signature                         │
-    │  • Checks permission (User.Read.All)                 │
-    │  • Returns user data                                 │
-    └──────────┬───────────────────────────────────────────┘
-               │
-               │ ⑥ JSON response
-               ↓
-    ┌──────────────────────┐
-    │   Your App/Script    │  ✓ Validate/process results
-    │                      │  {"value":[{"displayName":"Adam",...}]}
-    └──────────────────────┘
-
-
-PATTERN B: Call Downstream API Directly (Step 4)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-    ┌──────────────────────┐
-    │   Your App/Script    │
-    │   (PowerShell)       │
-    └──────────┬───────────┘
-               │
-               │ ① POST /DownstreamApiUnauthenticated/graph
-               │    ?optionsOverride.RelativePath=users
-               │    &AgentIdentity=aaaa1111...
-               ↓
-    ┌─────────────────────────────────────────────────────────────────┐
-    │              Sidecar Container                                  │
-    │                                                                 │
-    │  Blueprint App ID: 03f6638f...                                  │
-    │  Blueprint Secret: ***                                          │
-    │                                                                 │
-    │  ② Two-Token Exchange (T1/T2):                                 │
-    │     ┌────────────────────────────────────────────────┐          │
-    │     │ • Request T1 with Blueprint credentials        │          │
-    │     │   (03f6638f... + secret)                       │          │
-    │     │              ↓                                 │          │
-    │     │   Microsoft Entra ID                           │          │
-    │     │              ↓                                 │          │
-    │     │ • Receive Blueprint Token (T1)                 │          │
-    │     │              ↓                                 │          │
-    │     │ • Exchange T1 → Agent Token (T2)               │          │
-    │     │   for Agent ID: aaaa1111...                    │          │
-    │     │              ↓                                 │          │
-    │     │ • Receive Agent Token (T2)                     │          │
-    │     └────────────────────────────────────────────────┘          │
-    │                                                                 │
-    │  ③ Call Graph API with T2:                                     │
-    │     ┌────────────────────────────────────────────────┐          │
-    │     │ GET https://graph.microsoft.com/v1.0/users     │          │
-    │     │ Authorization: Bearer eyJ... (T2)              │          │
-    │     │              ↓                                 │          │
-    │     │   Microsoft Graph API                          │          │
-    │     │              ↓                                 │          │
-    │     │ • Validates token                              │          │
-    │     │ • Returns user data                            │          │
-    │     └────────────────────────────────────────────────┘          │
-    │                                                                 │
-    │  ④ Wraps response:                                             │
-    │     {"statusCode":200, "content":"{...users...}"}               │
-    │                                                                 │
-    └──────────┬──────────────────────────────────────────────────────┘
-               │
-               │ ⑤ Wrapped results
-               ↓
-    ┌──────────────────────┐
-    │   Your App/Script    │  [OK] Validate/process results
-    │                      │  Extract from content field
-    └──────────────────────┘
-
-
-KEY DIFFERENCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Pattern A: /AuthorizationHeaderUnauthenticated
-  ✓ Get token only (T2)
-  ✓ Your script calls downstream API
-  ✓ Full control over API call
-  ✓ Can inspect/validate token claims
-
-Pattern B: /DownstreamApiUnauthenticated
-  ✓ Token (T2) + API call in one request
-  ✓ Sidecar calls downstream API for you
-  ✓ Simpler code
-  ✓ Response wrapped in statusCode/content
+    ┌────────────┐   GET /AuthorizationHeader/graph           ┌──────────────────┐
+    │   Agent    ├────────────────────────────────────────────▶│ Sidecar          │
+    │ (your app) │   ?AgentIdentity=<agent-app-id>             │                  │
+    └────────────┘                                             │   T1: Blueprint  │
+          ▲                                                    │       token      │
+          │  Authorization: Bearer <T2>                        │         │        │
+          │                                                    │         ▼        │
+          └────────────────────────────────────────────────────┤   T2: Agent      │
+                                                               │       token      │
+    ┌────────────┐                                             └──────────────────┘
+    │ Downstream │  ← Agent calls with T2                               │
+    │    API     │                                                     ▼
+    └────────────┘                                        Microsoft Entra ID
 ```
 
-### Key Concepts
-               ↓
-    ┌──────────────────────┐
-    │   Your App/Script    │  ✓ Validate/process results
-    │                      │  {"value":[{"displayName":"Adam",...}]}
-    └──────────────────────┘
+### On-Behalf-Of (OBO) — **TF1**
 
-
-PATTERN B: Call Downstream API Directly (Step 4)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-    ┌──────────────────────┐
-    │   Your App/Script    │
-    │   (PowerShell)       │
-    └──────────┬───────────┘
-               │
-               │ ① POST /DownstreamApiUnauthenticated/graph
-               │    ?optionsOverride.RelativePath=users
-               │    &AgentIdentity=aaaa1111...
-               ↓
-    ┌────────────────────────────────────────────────────────┐
-    │              Sidecar Container                         │
-    │  Blueprint App ID: 03f6638f...                         │
-    │  Blueprint Secret: ***                                 │
-    └──────────┬─────────────────────────────────────────────┘
-               │
-               │ ② Two-Token Exchange (same as Pattern A)
-               │    • Gets Blueprint Token (T1)
-               │    • Exchanges T1 → Agent Token (T2)
-               ↓
-    ┌──────────────────────────────────────────────────────┐
-    │           Microsoft Entra ID                         │
-    │  • Issues T1, returns T2 for Agent aaaa1111...       │
-    └──────────┬───────────────────────────────────────────┘
-               │
-               │ ③ Sidecar gets Agent Token (T2)
-               ↓
-    ┌────────────────────────────────────────────────────────┐
-    │              Sidecar Container                         │
-    │  ④ Calls Graph API with T2                            │
-    │     GET https://graph.microsoft.com/v1.0/users         │
-    │     Authorization: Bearer eyJ...                       │
-    └──────────┬─────────────────────────────────────────────┘
-               │
-               │ ⑤ Graph validates & returns data
-               ↓
-    ┌──────────────────────────────────────────────────────┐
-    │           Microsoft Graph API                        │
-    │  • Returns user data to sidecar                      │
-    └──────────┬───────────────────────────────────────────┘
-               │
-               │ ⑥ Wrapped response
-               ↓
-    ┌────────────────────────────────────────────────────────┐
-    │              Sidecar Container                         │
-    │  Returns: {"statusCode":200,                           │
-    │            "content":"{...users...}"}                  │
-    └──────────┬─────────────────────────────────────────────┘
-               │
-               │ ⑦ Results received
-               ↓
-    ┌──────────────────────┐
-    │   Your App/Script    │  ✓ Validate/process results
-    │                      │  Extract from content field
-    └──────────────────────┘
-
-
-KEY DIFFERENCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Pattern A: /AuthorizationHeaderUnauthenticated
-  ✓ Get token only
-  ✓ Your script calls downstream API
-  ✓ Full control over API call
-  ✓ Can inspect/validate token claims
-
-Pattern B: /DownstreamApiUnauthenticated
-  ✓ Token + API call in one request
-  ✓ Sidecar calls downstream API
-  ✓ Simpler code
-  ✓ Response wrapped in statusCode/content
-```
-
-### Key Concepts
-
-**Blueprint Application** 🔷
-- Factory/template for creating Agent Identities
-- Holds the client secret (stored in sidecar)
-- Your application never needs to know the secret
-
-**Agent Identity** 🤖
-- Individual AI agent with its own identity
-- Gets its own access token
-- Has specific permissions assigned
-
-**Two-Token Flow** 🔄
-1. Application requests token for specific Agent ID
-2. Sidecar uses Blueprint credentials to get Blueprint token (T1)
-3. Sidecar exchanges T1 for Agent Identity token (T2)
-4. Application receives Agent Identity token (T2)
-
----
-
-## Prerequisites
-
-Before starting this lab, ensure you have:
-
-- Docker and Docker Compose installed
-- Agent Identity Blueprint created (via PowerShell workflow)
-- Agent Identity created with permissions assigned
-
-If you haven't run the PowerShell workflow yet:
-```powershell
-# In the repository root
-. ./EntraAgentID-Functions.ps1
-Start-EntraAgentIDWorkflow
-```
-
----
-
-## Lab Steps
-
-### Step 1: Prepare Environment Configuration
-
-Copy the example environment file:
-```powershell
-cd sidecar
-Copy-Item .env.example .env
-```
-
-### Step 2: Configure Your Credentials
-
-Edit `.env` with your values from the PowerShell workflow output:
-
-```powershell
-# Get these from: Start-EntraAgentIDWorkflow output
-TENANT_ID=<your-tenant-id>
-BLUEPRINT_APP_ID=<blueprint-app-id>      # <- IMPORTANT: Blueprint, not Agent!
-AGENT_CLIENT_ID=<agent-app-id>           # <- This is your Agent ID
-BLUEPRINT_CLIENT_SECRET=<blueprint-secret>
-```
-
-**💡 Pro Tip:** The sidecar is configured with **Blueprint** credentials, but you'll request tokens for the **Agent** identity.
-
-### Step 3: Start the Sidecar Container
-
-Launch the sidecar:
-```powershell
-docker-compose up -d
-```
-
-**Expected output:**
-```
-[+] Running 2/2
- ✔ Network sidecar_agent-network  Created
- ✔ Container agent-id-sidecar     Started
-```
-
-### Step 4: Verify Deployment
-
-Check that the sidecar is healthy:
-```powershell
-Invoke-RestMethod -Uri "http://localhost:5001/healthz"
-```
-
-**Expected response:** `Healthy`
-
-View container logs:
-```powershell
-docker-compose logs -f sidecar
-```
-
-**✅ Success indicators:**
-- Container status: `Up`
-- Health endpoint returns `Healthy`
-- No error messages in logs
-
----
-
-## Lab Steps
-
-### Step 1: Get an Agent Identity Token
-
-**Goal:** Request a secure token for your AI agent from the sidecar
-
-**What you're simulating:** Your AI agent needs to authenticate to access Microsoft 365 data.
-
-**Steps:**
-
-1. **Set your Agent App ID** (get this from PowerShell workflow output):
-```powershell
-$agentAppId = "YOUR-AGENT-APP-ID"
-```
-
-2. **Request a token from the sidecar:**
-```powershell
-$response = Invoke-RestMethod -Uri "http://localhost:5001/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId"
-$response
-```
-
-3. **Observe the response:**
-```json
-{
-  "authorizationHeader": "Bearer eyJ0eXAiOiJKV1QiLCJub25jZSI6..."
-}
-```
-
-**🎓 What just happened?**
+A signed-in user asks the agent to do something on their behalf. The downstream API must see the user's identity, not just the agent's.
 
 ```
-Your Request
-    ↓
-Sidecar receives: "Give me a token for Agent ID abc123"
-    ↓
-Sidecar thinks: "I have Blueprint credentials, let me use those..."
-    ↓
-Step 1: Sidecar → Microsoft Entra: "I'm the Blueprint, give me Blueprint token (T1)"
-    ↓
-Step 2: Sidecar → Microsoft Entra: "Here's T1, exchange it for Agent abc123 token (T2)"
-    ↓
-Step 3: Microsoft Entra validates and returns Agent Identity token (T2)
-    ↓
-Sidecar returns T2 to your application
-    ↓
-Your Application now has Agent Identity token! 🎉
+    User ──sign-in──▶ Client SPA ──(Tc: user token)──▶ Agent ──▶ Sidecar
+                                                                    │
+                                                                    │ OBO exchange:
+                                                                    │   Tc + Blueprint
+                                                                    ▼
+                                                         Microsoft Entra ID
+                                                                    │
+                                                                    ▼
+                                                               TF1 = Agent-on-behalf-of-user
+                                                                    │
+                                                                    ▼
+                                                         Agent ──▶ Downstream API
+                                                                    (sees both user and agent claims)
 ```
 
-**Security win:** Your application never saw the Blueprint secret! The sidecar handled everything.
+Both flows are demonstrated end-to-end in [`dev/`](dev/README.md) and [`aws/`](aws/README.md).
 
----
-
-### Step 2: Call Microsoft Graph API to Get Users
-
-**Goal:** Use the Agent Identity token to retrieve user data from Microsoft 365
-
-**What you're simulating:** Your AI agent (DataBot) needs to look up users in your organization's directory.
-
-**PowerShell:**
-```powershell
-# Step 1: Get the Agent Identity token
-$agentAppId = "YOUR-AGENT-APP-ID"
-$response = Invoke-RestMethod -Uri "http://localhost:5001/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId"
-
-# Step 2: Extract the token (already includes "Bearer " prefix)
-$authHeader = $response.authorizationHeader
-
-# Step 3: Call Microsoft Graph to list users
-$users = Invoke-RestMethod -Method GET `
-    -Uri "https://graph.microsoft.com/v1.0/users?`$top=5" `
-    -Headers @{ "Authorization" = $authHeader }
-
-# Step 4: Display results
-Write-Host "`n[OK] Successfully retrieved users using Agent Identity!" -ForegroundColor Green
-Write-Host "Agent has access to $($users.'@odata.count') users`n" -ForegroundColor Cyan
-$users.value | Select-Object displayName, userPrincipalName, jobTitle | Format-Table
-```
-
-**Expected Result:** 
-```
-[OK] Successfully retrieved users using Agent Identity!
-Agent has access to users
-
-displayName    userPrincipalName                          jobTitle
------------    -----------------                          --------
-John Doe       john@contoso.com                          Developer
-Jane Smith     jane@contoso.com                          Manager
-Bob Johnson    bob@contoso.com                           Analyst
-```
-
-**🎓 What just happened?**
+## How the samples fit together
 
 ```
-Your Application
-    ↓ (with Agent Identity token)
-Microsoft Graph API
-    ↓
-Graph validates: "Is this token valid?"
-    ↓
-Graph checks: "Does this Agent have User.Read.All permission?"
-    ↓
-✅ Token valid + Permission granted = Return user data
-    ↓
-Your Application receives user list
+┌──────────────────────────────────────────────────────────────┐
+│                  sidecar/ samples                            │
+│                                                              │
+│  dev/    ─┐                                                  │
+│  aws/    ─┼──▶  weather-api/  (shared, validates tokens)    │
+│  (gcp/)  ─┘                                                  │
+│                                                              │
+│  Each agent sample includes its own auth sidecar container.  │
+│  All three call the same weather-api for an apples-to-apples │
+│  cross-cloud demo.                                           │
+└──────────────────────────────────────────────────────────────┘
 ```
 
-**This proves:**
-- ✅ Your Agent Identity is working
-- ✅ The permissions you assigned (User.Read.All) are active
-- ✅ Your AI agent can now safely access Microsoft 365 data
-- ✅ Everything is logged under the Agent's identity (audit trail)
+- **[`dev/`](dev/README.md)** — LangChain + Ollama (local), runs entirely offline via `docker-compose`. Fastest path to a working demo. Ties to TOC §2.3.
+- **[`aws/`](aws/README.md)** — LangChain + AWS Bedrock (Claude) with Azure→AWS OIDC federation via the `azure-token-refresher` companion. Ties to TOC §3.1.
+- **[`weather-api/`](weather-api/README.md)** — minimal token-validated mock API. RS256 signature check via JWKS, issuer and audience validation, agent-identity claim verification.
 
----
+For deploying any of the above to Azure, see [`../deploy/azure/container-apps/`](../deploy/azure/container-apps/) — zero stored secrets, federated credentials only.
 
-### Step 3: Verify Token Claims (Optional Deep Dive)
+## What you'll learn by running the samples
 
-**Goal:** Inspect the token to see exactly what permissions and identity it contains
+- The difference between a Blueprint and an Agent Identity, and why agents need their own identity.
+- How the sidecar exposes `/AuthorizationHeader` (get token) and `/DownstreamApi` (token + proxied call) endpoints.
+- How to hand a user's token (`Tc`) to the agent and have the sidecar mint an OBO Agent token (`TF1`).
+- How the downstream API validates agent tokens cryptographically — signature, issuer, `xms_par_app_azp`, audience.
+- How to swap from `ClientSecret` (dev) to `SignedAssertionFromManagedIdentity` (Azure production) without changing a line of agent code.
 
-**PowerShell:**
-```powershell
-# Get a fresh token
-$response = Invoke-RestMethod -Uri "http://localhost:5001/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId"
-$token = $response.authorizationHeader -replace "Bearer ", ""
+## Next steps
 
-# Decode the token (JWT tokens are base64 encoded)
-$tokenParts = $token.Split('.')
-$payload = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String(
-    $tokenParts[1].PadRight($tokenParts[1].Length + (4 - $tokenParts[1].Length % 4) % 4, '=')
-))
+| To… | Go to |
+|---|---|
+| Set up Blueprint + Agent Identity in your Entra tenant | [`../scripts/README.md`](../scripts/README.md) |
+| Run a local-LLM demo in five minutes | [`dev/README.md`](dev/README.md) |
+| Run the same demo against AWS Bedrock | [`aws/README.md`](aws/README.md) |
+| Deploy to Azure Container Apps (no stored secrets) | [`../deploy/azure/container-apps/`](../deploy/azure/container-apps/) |
 
-# Parse and display
-$claims = $payload | ConvertFrom-Json
+## Further reading
 
-Write-Host "`n[INFO] Token Analysis:" -ForegroundColor Cyan
-Write-Host "App ID (appid):     $($claims.appid)" -ForegroundColor Yellow
-Write-Host "Audience (aud):     $($claims.aud)" -ForegroundColor Yellow
-Write-Host "Issuer (iss):       $($claims.iss)" -ForegroundColor Yellow
-Write-Host "Roles/Permissions:  $($claims.roles -join ', ')" -ForegroundColor Green
-Write-Host "Agent Identity (xms_frd): $($claims.xms_frd)" -ForegroundColor Magenta
-Write-Host "`nThis token proves the Agent has these permissions: $($claims.roles -join ', ')`n"
-```
-
-**What you'll see:**
-```
-[INFO] Token Analysis:
-App ID (appid):     <your-agent-app-id>
-Audience (aud):     https://graph.microsoft.com
-Issuer (iss):       https://sts.windows.net/[tenant-id]/
-Roles/Permissions:  User.Read.All
-Agent Identity (xms_frd): FederatedAgent
-
-[OK] This token proves the Agent has these permissions: User.Read.All
-```
-
-**🎓 What this means:**
-- **appid**: This is YOUR Agent's unique ID
-- **aud**: Token is for Microsoft Graph API
-- **roles**: The permissions you assigned in the PowerShell workflow
-- **xms_frd**: Special claim proving this is an Agent Identity (not a regular app)
-
----
-
-### Step 4: One-Request API Call (Simplified Pattern)
-
-**Goal:** Use the simplified endpoint that combines token acquisition and API calling
-
-**What you're simulating:** For simple scenarios, you can skip manual token management and let the sidecar do everything.
-
-**PowerShell:**
-```powershell
-# IMPORTANT: Use -Method POST even though we're doing a GET to the downstream API
-$agentAppId = "YOUR-AGENT-APP-ID"
-$relativePath = "users?`$top=5"
-
-Write-Host "[INFO] Calling Graph API via sidecar proxy..." -ForegroundColor Cyan
-$response = Invoke-RestMethod `
-    -Method POST `
-    -Uri "http://localhost:5001/DownstreamApiUnauthenticated/graph?optionsOverride.RelativePath=$relativePath&AgentIdentity=$agentAppId"
-
-# Parse the wrapped response
-$data = $response.content | ConvertFrom-Json
-Write-Host "[OK] Retrieved users via simplified endpoint!`n" -ForegroundColor Green
-$data.value | Select-Object displayName, userPrincipalName | Format-Table
-```
-
-**[INFO] What's different?**
-
-**Step 2 (Two steps):**
-```
-1. Your App -> Sidecar: "Give me token"
-2. Your App -> Graph API: "Here's my token, give me data"
-```
-
-**Step 4 (One step):**
-```
-1. Your App -> Sidecar: "Get users for me"
-   Sidecar -> Graph API: (handles token + request)
-   Sidecar -> Your App: "Here's the data"
-```
-
-**Trade-offs:**
-- [OK] **Simplified:** Less code, one request
-- [OK] **Good for:** Simple CRUD operations
-- [WARN] **Less flexible:** Can't reuse token, limited HTTP control
-- [WARN] **Response wrapped:** Need to parse `content` field
-
-**When to use:**
-- Use Step 2 pattern (token-only) for: Production apps, complex scenarios, token reuse
-- Use Step 4 pattern (full-proxy) for: Quick prototypes, simple demos, single API calls
-
----
-
-## Understanding the Endpoints
-
-### Available Sidecar Endpoints
-
-### Health Check
-```powershell
-Invoke-RestMethod -Uri "http://localhost:5001/healthz"
-```
-Expected: `Healthy`
-
-### Get Agent Identity Token
-
-**Use the `AgentIdentity` query parameter with your Agent App ID:**
-
-```powershell
-# Replace with your Agent App ID from workflow
-$agentAppId = "YOUR-AGENT-APP-ID"
-$response = Invoke-RestMethod -Uri "http://localhost:5001/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId"
-$response
-```
-
-**Example Response:**
-```json
-{
-  "authorizationHeader": "Bearer eyJ0eXAiOiJKV1QiLCJub25jZSI6..."
-}
-```
-
-### Extract Token and Call Microsoft Graph API
-
-```powershell
-# Get token
-$agentAppId = "YOUR-AGENT-APP-ID"
-$response = Invoke-RestMethod -Uri "http://localhost:5001/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId"
-
-# Extract Bearer token (already includes "Bearer " prefix)
-$authHeader = $response.authorizationHeader
-
-# Use with Microsoft Graph
-$users = Invoke-RestMethod -Method GET `
-    -Uri "https://graph.microsoft.com/v1.0/users?`$top=5" `
-    -Headers @{ "Authorization" = $authHeader }
-
-$users.value | Select-Object displayName, userPrincipalName
-```
-
-## Available Sidecar Endpoints
-
-| Endpoint | Method | Auth Required | Description |
-|----------|--------|---------------|-------------|
-| `/healthz` | GET | No | Health check |
-| `/AuthorizationHeaderUnauthenticated/graph?AgentIdentity={agentAppId}` | GET | No | **For autonomous agents** - Get Agent Identity token only |
-| `/DownstreamApiUnauthenticated/graph?optionsOverride.RelativePath={path}&AgentIdentity={agentAppId}` | **POST** | No | **For autonomous agents** - Get token AND call API in one request |
-| `/AuthorizationHeader/graph?AgentIdentity={agentAppId}` | GET | Yes (Bearer token) | **For interactive agents** - Get Agent Identity token on-behalf-of user |
-| `/DownstreamApi/graph?optionsOverride.RelativePath={path}&AgentIdentity={agentAppId}` | Matches downstream | Yes (Bearer token) | **For interactive agents** - Get token AND call API with user context |
-
-### Understanding Endpoint Authentication
-
-**🔓 Unauthenticated Endpoints** (No incoming token required):
-- `/AuthorizationHeaderUnauthenticated` - Get Agent Identity token only
-- `/DownstreamApiUnauthenticated` - Get token AND call API in one request
-- Your application requests tokens directly without needing an incoming user/app token
-- **These are for autonomous agents operating independently**
-
-**🔒 Authenticated Endpoints** (Require incoming Bearer token):
-- `/AuthorizationHeader` - For on-behalf-of (OBO) scenarios
-- `/DownstreamApi` - For proxied API calls with user context
-- Your application must already have a valid bearer token to pass to the sidecar
-- Used for interactive agents or when chaining token flows
-
-### When to Use Each Endpoint
-
-**For Autonomous Agents** (No user context):
-
-**Option 1: `/AuthorizationHeaderUnauthenticated`** (✅ Recommended)
-- Get Agent Identity token only
-- You make the HTTP call to downstream API yourself
-- Full control over HTTP client, headers, retries
-- Can reuse token for multiple API calls
-- Best for complex scenarios or multiple APIs
-
-**Option 2: `/DownstreamApiUnauthenticated`** (Simplified)
-- Get token AND call API in one request
-- Sidecar handles token acquisition and HTTP call
-- Less code, simpler integration
-- Best for straightforward API calls
-- Response wrapped in JSON with statusCode, headers, content
-
-**For Interactive Agents** (With user context):
-- `/AuthorizationHeader` - Token only with user context
-- `/DownstreamApi` - Token + API call with user context
-- Require incoming bearer token from user session
-
-### Using DownstreamApiUnauthenticated for Autonomous Agents
-
-The `/DownstreamApiUnauthenticated` endpoint combines token acquisition and API calling in a single request - perfect for straightforward scenarios:
-
-**PowerShell Example:**
-```powershell
-# Get users list in one call (no incoming token required)
-# IMPORTANT: Use -Method POST even for downstream GET operations!
-$agentAppId = "YOUR-AGENT-APP-ID"
-$relativePath = "users?`$top=5"
-
-$response = Invoke-RestMethod `
-    -Method POST `
-    -Uri "http://localhost:5001/DownstreamApiUnauthenticated/graph?optionsOverride.RelativePath=$relativePath&AgentIdentity=$agentAppId"
-
-# Response is wrapped - parse the content
-$data = $response.content | ConvertFrom-Json
-$data.value | Select-Object displayName, userPrincipalName
-```
-
-**Response Format:**
-```json
-{
-  "statusCode": 200,
-  "headers": {
-    "content-type": "application/json; charset=utf-8"
-  },
-  "content": "{\"@odata.context\":\"...\",\"value\":[...]}"
-}
-```
-
-**⚠️ Important Notes:**
-- The **sidecar endpoint** `/DownstreamApiUnauthenticated` always requires **POST method**
-- To specify the **downstream API** HTTP method (GET, POST, PUT, DELETE), use `optionsOverride.HttpMethod` query parameter
-- If `optionsOverride.HttpMethod` is not specified, downstream API defaults to GET
-- Example: POST to sidecar, but GET from Microsoft Graph (default behavior)
-
-**When to use `/DownstreamApiUnauthenticated` vs `/AuthorizationHeaderUnauthenticated`:**
-- Use `/DownstreamApiUnauthenticated` for simple, single API calls (less code)
-- Use `/AuthorizationHeaderUnauthenticated` when you need token reuse or full HTTP control
-
----
-
-## Troubleshooting
-
-### Issue: Container name conflict
-
-**Error:** `The container name "/agent-id-sidecar" is already in use`
-
-**Solution:**
-```powershell
-# Stop and remove existing container
-docker stop agent-id-sidecar
-docker rm agent-id-sidecar
-
-# Restart from sidecar folder
-docker-compose up -d
-```
-
----
-
-### Issue: 405 Method Not Allowed
-
-**Error:** `Response status code does not indicate success: 405 (Method Not Allowed)`
-
-**Common causes:**
-
-1. **Using GET instead of POST for `/DownstreamApiUnauthenticated`**
-   ```powershell
-   # ❌ Wrong - Missing -Method POST
-   $response = Invoke-RestMethod -Uri "http://localhost:5001/DownstreamApiUnauthenticated/..."
-   
-   # ✅ Correct - Must use POST
-   $response = Invoke-RestMethod -Method POST -Uri "http://localhost:5001/DownstreamApiUnauthenticated/..."
-   ```
-
-2. **Using authenticated endpoints without bearer token**
-   - Use `Unauthenticated` endpoints for autonomous agents
-
----
-
-### Issue: Empty token or "Access token is empty"
-
-**Cause:** `.env` file has placeholder values
-
-**Solution:**
-```powershell
-# Verify .env has actual values (not placeholders)
-Get-Content .env
-
-# Get your Blueprint App ID from PowerShell
-Get-BlueprintList
-
-# Update .env and restart
-docker-compose down
-docker-compose up -d
-```
-
----
-
-### Issue: Token doesn't have permissions
-
-**Symptoms:** API returns 403 Forbidden
-
-**Solution:**
-- Wait 5-10 minutes for permissions to propagate in Microsoft Entra ID
-- Verify permissions were added to the **Agent Identity** (not Blueprint)
-- Check permissions with PowerShell:
-  ```powershell
-  Test-AgentIdentityToken -AgentAppId "your-agent-app-id"
-  ```
-
----
-
-### Issue: Endpoint returns 404
-
-**Causes:**
-- Using `/health` instead of `/healthz`
-- Downstream API name doesn't match configuration (must be `graph`)
-
----
-
-### Issue: DownstreamApi returns unexpected results
-
-**Check:**
-- Response is wrapped - parse the `content` field
-- Use `optionsOverride.RelativePath` format (not just `RelativePath`)
-- For POST/PUT/DELETE, add `optionsOverride.HttpMethod` parameter
-
----
-
-## Troubleshooting
-
-### Issue: Container name conflict
-
-**Error:** `The container name "/agent-id-sidecar" is already in use`
-
-**Cause:** A sidecar container is already running (possibly from the root project folder)
-
-**Solution:**
-```powershell
-# Check if container is running
-docker ps | Select-String "agent-id-sidecar"
-
-# Stop the existing container
-docker stop agent-id-sidecar
-
-# Remove the existing container
-docker rm agent-id-sidecar
-
-# Or use docker-compose from where it was started
-docker-compose down
-
-# Then start from sidecar folder
-docker-compose up -d
-```
-
-### Container won't start
-```powershell
-docker-compose logs sidecar
-```
-
-### Invalid credentials error
-- Verify your `.env` file has the correct values
-- **Most common issue:** Using Agent App ID instead of Blueprint App ID in `BLUEPRINT_APP_ID`
-- Make sure the Blueprint Client Secret is the full secret (not truncated)
-- Run `Get-Content .env` to verify all values are populated (no "REPLACE_WITH_" placeholders)
-
-### Empty token or "Access token is empty" error
-**This means `.env` has placeholder values instead of actual IDs.**
-
-Get your Blueprint App ID from PowerShell:
-```powershell
-# If workflow result still in session
-$result.Blueprint.BlueprintAppId
-
-# Or query all blueprints
-Get-BlueprintList
-```
-
-Then update `.env` and restart:
-```powershell
-# Edit .env file with your preferred editor
-notepad .env
-# Or on macOS/Linux:
-# nano .env
-
-# Restart containers
-docker-compose down
-docker-compose up -d
-```
-
-### Endpoint returns 404
-- Check you're using `/healthz` (with 'z') not `/health`
-- Verify the downstream API name is `graph` (configured in docker-compose.yml)
-
-### Token doesn't have permissions
-- Wait 5-10 minutes for permissions to propagate in Microsoft Entra ID
-- Permissions are added to the Agent Identity, not the Blueprint
-- Verify permissions were added via `Test-AgentIdentityToken` in PowerShell
-
-### 405 Method Not Allowed error
-**Error:** `Response status code does not indicate success: 405 (Method Not Allowed)`
-
-**Common causes:**
-
-1. **Using GET instead of POST for `/DownstreamApiUnauthenticated`**
-   - `/DownstreamApiUnauthenticated` endpoint **requires POST method**, even for downstream GET operations
-   - Solution: Add `-Method POST` to your Invoke-RestMethod call
-
-2. **Using authenticated endpoints without bearer token**
-   - `/AuthorizationHeader` or `/DownstreamApi` require incoming bearer token
-   - Solution: Use Unauthenticated endpoints for autonomous agents
-
-**Example - Correct approach for autonomous agents:**
-```powershell
-# ✅ Option 1: Get token only (GET is OK)
-$response = Invoke-RestMethod -Uri "http://localhost:5001/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId"
-
-# ✅ Option 2: Get token AND call API (MUST use POST)
-$response = Invoke-RestMethod `
-    -Method POST `
-    -Uri "http://localhost:5001/DownstreamApiUnauthenticated/graph?optionsOverride.RelativePath=users&AgentIdentity=$agentAppId"
-```
-
-**Example - Interactive agent with user token:**
-```powershell
-# ✅ Correct - Auth header required for authenticated endpoints
-$response = Invoke-RestMethod `
-    -Uri "http://localhost:5001/DownstreamApi/graph?optionsOverride.RelativePath=me&AgentIdentity=$agentAppId" `
-    -Headers @{ "Authorization" = "Bearer $userToken" }
-```
-
-### DownstreamApi endpoint returns unexpected results
-- Use `optionsOverride.RelativePath` query parameter format (not just `RelativePath`)
-- Response is wrapped in JSON with `statusCode`, `headers`, and `content` fields
-- Parse the `content` field to get the actual API response
-- For POST/PUT/PATCH requests, add `optionsOverride.HttpMethod` parameter
-- See [official documentation](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/scenarios/call-downstream-api) for complete examples
-
----
-
-## Lab Cleanup
-
-Stop and remove containers:
-```powershell
-docker-compose down
-```
-
-Remove volumes (if any):
-```powershell
-docker-compose down -v
-```
-
----
-
-## Additional Resources
-
-### Official Documentation
 - [Microsoft Entra SDK for Agent Identities](https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/microsoft-entra-sdk-for-agent-identities)
-- [SDK Endpoints Reference](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/endpoints)
+- [SDK endpoints reference](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/endpoints)
 - [Call a downstream API](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/scenarios/call-downstream-api)
 - [Python integration examples](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/scenarios/using-from-python)
-- [TypeScript integration examples](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/scenarios/using-from-typescript)
-
-### Repository Resources
-- Main README: [../README.md](../README.md)
-- PowerShell Functions: [../EntraAgentID-Functions.ps1](../EntraAgentID-Functions.ps1)
-
----
-
-## Lab Summary
-
-**🎉 Congratulations! You've completed the lab!**
-
-### What You Accomplished
-
-✅ **Deployed a secure token service** (Microsoft Entra SDK sidecar)  
-✅ **Configured it with Blueprint credentials** (secrets stay in container)  
-✅ **Requested Agent Identity tokens** (two-token exchange in action)  
-✅ **Called Microsoft Graph API** to retrieve users  
-✅ **Verified your agent's permissions** (User.Read.All in token claims)  
-✅ **Tested both patterns** (token-only and full-proxy)
-
-### The Complete Flow You Just Tested
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│              WHAT YOU JUST DID IN THIS LAB                      │
-└─────────────────────────────────────────────────────────────────┘
-
-Prerequisites (Done via PowerShell):
-  [OK] Created Blueprint Application
-  [OK] Created Agent Identity  
-  [OK] Assigned User.Read.All permission to Agent
-
-Lab Steps:
-  1. Deployed sidecar with Blueprint credentials
-  2. Requested Agent Identity token -> Got JWT with appid & permissions
-  3. Called Graph API -> Retrieved users successfully
-  4. Verified token claims -> Saw User.Read.All permission
-  5. Tested simplified proxy -> Same result, less code
-
-Result:
-  [OK] Your AI agent can now safely access Microsoft 365 data!
-  [LOCK] Secrets managed by sidecar (never exposed to your app)
-  [INFO] All actions audited under Agent's identity
-  [OK] Production-ready authentication pattern
-```
-
-### Real-World Impact
-
-**Before Agent Identity:**
-```
-❌ Store secrets in app configuration (security risk)
-❌ Broad service principal permissions (over-privileged)
-❌ Hard to audit individual AI agents (all use same identity)
-❌ Complex token management code (boilerplate)
-```
-
-**After Agent Identity (What You Just Learned):**
-```
-✅ Secrets in sidecar only (secure by design)
-✅ Granular per-agent permissions (least privilege)
-✅ Individual agent audit trails (compliance ready)
-✅ Simple token requests (sidecar handles complexity)
-```
-
-### Key Concepts Mastered
-
-1. **Two-Token Exchange**: Blueprint token (T1) → Agent token (T2)
-2. **Secret Management**: Sidecar stores credentials, app never sees them
-3. **Token Patterns**: 
-   - `/AuthorizationHeaderUnauthenticated` for flexibility
-   - `/DownstreamApiUnauthenticated` for simplicity
-4. **JWT Claims**: Understanding `appid`, `roles`, `xms_frd` in tokens
-5. **Autonomous Agents**: No user context required, agent acts independently
-
-### What You Can Build Now
-
-**Production Scenarios You're Ready For:**
-
-🤖 **AI-Powered Apps**
-- Customer support chatbot that reads user info
-- Meeting scheduler that accesses calendars  
-- Email assistant that manages messages
-- Data analytics agent that queries SharePoint
-
-🏢 **Enterprise Integrations**
-- Third-party SaaS connecting to Microsoft 365
-- Partner applications accessing your tenant data
-- Automation scripts with proper agent identity
-- Multi-agent systems with individual permissions
-
-🔐 **Secure By Design**
-- No secrets in application code
-- Centralized credential management
-- Per-agent permission scoping
-- Complete audit trail per agent
-
-### Next Steps
-
-1. **Build Your First Agent App**
-   - Use the patterns from Step 2 in your application
-   - Integrate with Python, Node.js, or your preferred language
-   - See: [Python examples](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/scenarios/using-from-python) | [TypeScript examples](https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/scenarios/using-from-typescript)
-
-2. **Explore More Permissions**
-   - Try Mail.Read for email scenarios
-   - Test Calendar.Read for scheduling
-   - Combine multiple permissions for richer agents
-   - See: [Grant agent access guide](https://learn.microsoft.com/en-us/entra/agent-id/identity-professional/grant-agent-access-microsoft-365)
-
-3. **Deploy to Production**
-   - Move sidecar to Kubernetes/AKS
-   - Use managed identities for Blueprint credentials
-   - Implement monitoring and logging
-   - Set up agent lifecycle management
-
-4. **Learn More**
-   - Review the [main README](../README.md) for full PowerShell workflow
-   - Study the [PowerShell functions](../EntraAgentID-Functions.ps1) source code
-   - Read [Microsoft's Agent ID overview](https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/what-is-agent-id-platform)
-
-### Key Takeaways
-
-💡 **Remember:**
-- Sidecar manages secrets - your app never sees them
-- Blueprint credentials stay in the sidecar container  
-- Agent Identity is passed as a query parameter
-- Autonomous agents don't need incoming user tokens
-- The sidecar eliminates boilerplate token management code
-- Each agent gets its own identity and audit trail
-- This is production-ready, not just a demo pattern
-
-**You're now ready to build secure, enterprise-grade AI agents with Microsoft Entra Agent Identity!** 🚀
-
----
-
-## Architecture Reference
-
-### Detailed Component Interaction
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    DETAILED ARCHITECTURE                         │
-└─────────────────────────────────────────────────────────────────┘
-
-┌─────────────────┐
-│  Your App       │
-│  (Port 8080)    │
-└────────┬────────┘
-         │ HTTP: GET /AuthorizationHeaderUnauthenticated/graph?AgentIdentity=xxx
-         ↓
-┌─────────────────┐
-│  Sidecar        │
-│  (Port 5001)    │  ← Configured with Blueprint credentials
-└────────┬────────┘
-         │ Two-Token Exchange (T1 → T2)
-         ↓
-┌─────────────────┐
-│  Microsoft      │
-│  Entra ID       │
-└─────────────────┘
-```
-
-**Key Points:**
-- Sidecar is configured with **Blueprint** App ID and Secret
-- Your app requests tokens by passing **Agent** App ID as query parameter
-- Sidecar handles the two-token exchange automatically
-- Your app never needs to handle secrets!
-
----
-
-## Quick Reference
-
-### Common Commands
-
-```powershell
-# Start sidecar
-docker-compose up -d
-
-# Check health
-Invoke-RestMethod -Uri "http://localhost:5001/healthz"
-
-# View logs
-docker-compose logs -f sidecar
-
-# Stop sidecar
-docker-compose down
-```
-
-### Token Patterns
-
-**Pattern 1: Token Only** (Recommended for most scenarios)
-```powershell
-$agentAppId = "AGENT_ID"
-$response = Invoke-RestMethod -Uri "http://localhost:5001/AuthorizationHeaderUnauthenticated/graph?AgentIdentity=$agentAppId"
-$response.authorizationHeader
-```
-
-**Pattern 2: Token + API Call** (Simplified integration)
-```powershell
-$agentAppId = "AGENT_ID"
-$response = Invoke-RestMethod -Method POST -Uri "http://localhost:5001/DownstreamApiUnauthenticated/graph?optionsOverride.RelativePath=users&AgentIdentity=$agentAppId"
-$response.content | ConvertFrom-Json
-```
-
----
-
-## Interactive Demo: LLM Weather Agent
-
-The docker-compose includes an interactive demo with a chat UI that shows Agent Identity in action.
-
-### What's Included
-
-| Service | Port | Description |
-|---------|------|-------------|
-| Sidecar | 5001 | Microsoft Entra Agent ID sidecar |
-| Weather API | 8080 | Mock weather API that validates Agent ID tokens |
-| LLM Agent | 3000 | Chat UI with weather agent |
-| Ollama | 11434 | Local LLM for natural responses (optional) |
-
-### Start the Full Demo
-
-```powershell
-# Make sure .env is configured
-cd sidecar
-docker-compose up -d
-
-# Open the chat UI
-Start-Process "http://localhost:3000"
-```
-
-### How It Works
-
-1. **You ask:** "What's the weather in Seattle?"
-2. **LLM Agent** calls Sidecar to get Agent Identity token
-3. **Sidecar** performs T1/T2 exchange with Entra ID
-4. **LLM Agent** calls Weather API with the token
-5. **Weather API** validates the Agent Identity token
-6. **Response** is displayed with debug info showing the token flow
-
-### Architecture
-
-```
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Chat UI       │───▶│   Sidecar       │───▶│  Microsoft      │
-│  (Port 3000)    │    │  (Port 5001)    │    │  Entra ID       │
-└────────┬────────┘    └─────────────────┘    └─────────────────┘
-         │                                            │
-         │ Agent Identity Token (T2)                  │
-         ▼                                            ▼
-┌─────────────────┐                          ┌─────────────────┐
-│  Weather API    │◀─────────────────────────│  Token (T2)     │
-│  (Port 8080)    │   Validates token        └─────────────────┘
-└─────────────────┘
-```
-
-### Demo Without Ollama
-
-The LLM (Ollama) is optional. Without it, the agent will still:
-- Get tokens from the sidecar
-- Call the Weather API
-- Display formatted weather data
-- Show the complete debug flow
-
-To run without Ollama (faster startup):
-```powershell
-docker-compose up -d sidecar weather-api llm-agent
-```
-
----
-
-## Next Steps
-
-Now that you understand the fundamentals of Agent Identity tokens, try the **complete end-to-end demo**:
-
-👉 **[LLM Agent Demo](./llm-agent/README.md)** - A visual demonstration featuring:
-- 🖥️ **Chat UI** - Interactive web interface to ask weather questions
-- 🔍 **Token Flow Debug Panel** - Watch the Agent Identity token flow in real-time
-- 🌤️ **Real Weather API** - Calls Open-Meteo for actual weather data
-- 🔐 **Token Validation** - API validates JWT before returning data
-- 📊 **JWT Claims Display** - See the decoded token claims (appid, oid, tid, roles)
-
-```powershell
-# Quick start the full demo
-cd sidecar
-docker-compose up -d
-Start-Process "http://localhost:3000"
-```
-
----
-
-*End of Lab Guide*
 

--- a/sidecar/aws/README.md
+++ b/sidecar/aws/README.md
@@ -1,10 +1,10 @@
-# AWS Bedrock Sidecar (Cloud LLM Edition)
+# AWS: Amazon Bedrock Agent with Entra Agent ID Sidecar
 
 A visual, hands-on demonstration of how AI agents use **Microsoft Entra Agent ID** — via the official **Microsoft Entra SDK auth sidecar** — to securely call downstream APIs. This variant uses **AWS Bedrock** (Anthropic Claude) as the LLM, proving the sidecar pattern works identically across clouds.
 
 > **Looking for the local-only version?** See [`sidecar/dev`](../dev/README.md) — same architecture, runs entirely offline with Ollama.
 >
-> **New to Agent ID?** Start with the [Sidecar Guide](../SIDECAR-GUIDE.md) for the fundamentals.
+> **New to Agent ID?** Start with [The Sidecar Design Pattern](../README.md) for the concepts.
 
 ---
 

--- a/sidecar/dev/README.md
+++ b/sidecar/dev/README.md
@@ -1,10 +1,8 @@
-# Local Dev Sidecar (Ollama Edition)
+# Run the Sidecar Locally — Developer Quickstart (Ollama)
 
 A visual, hands-on demonstration of how AI agents use **Microsoft Entra Agent ID** — via the official **Microsoft Entra SDK auth sidecar** — to securely call downstream APIs. Runs entirely on your laptop with a local LLM via [Ollama](https://ollama.com).
 
-> **TODO:** Screenshots of the UI (chat view, token trace panel, OBO sign-in) need to be captured and added to `docs/images/` before publishing.
-
-> **New to Agent ID?** Start with the [Sidecar Guide](../SIDECAR-GUIDE.md) for the fundamentals. This sample builds on that with a complete end-to-end demo.
+> **New to Agent ID?** Start with [The Sidecar Design Pattern](../README.md) for the concepts. This sample puts the pattern into a working end-to-end app with a chat UI and token-trace panel.
 
 ---
 

--- a/sidecar/weather-api/README.md
+++ b/sidecar/weather-api/README.md
@@ -1,0 +1,86 @@
+# Weather API — Shared Downstream API
+
+A minimal Flask app that plays the role of *"the downstream API your agent calls"* in every sample in this repo. It validates incoming Agent Identity tokens and returns real weather data from [Open-Meteo](https://open-meteo.com) (no key required).
+
+This service is intentionally boring. The interesting part is the token validation — it proves that Entra Agent ID tokens work cryptographically end-to-end.
+
+## What it does
+
+- Exposes `GET /weather?city=<name>` and `GET /healthz`.
+- On every request to `/weather`, validates the `Authorization: Bearer <token>` header:
+  - **Signature** — RS256 verified against the JWKS at `https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys`
+  - **Issuer** — must match `https://sts.windows.net/<tenant>/` or `https://login.microsoftonline.com/<tenant>/v2.0`
+  - **Audience** — configurable; defaults to Microsoft Graph (`https://graph.microsoft.com`) so the same Agent tokens work for local testing
+  - **Agent-identity marker** — the `xms_par_app_azp` claim (present in Agent tokens, absent in plain app-only tokens) is logged so you can see which Blueprint minted the call
+- Returns real weather on success, HTTP 401 with a reason on any validation failure.
+
+## How the samples use it
+
+```
+┌─────────────┐                  ┌──────────────────┐
+│ Agent       │  Bearer <T2>     │   weather-api    │
+│ (dev/aws)   ├─────────────────▶│                  │
+└─────────────┘                  │  - verify token  │
+                                 │  - call          │
+                                 │    Open-Meteo    │
+                                 └──────────────────┘
+```
+
+Both the [`dev/`](../dev/README.md) (Ollama) and [`aws/`](../aws/README.md) (Bedrock) sidecar samples call this exact same container — the cross-cloud story only works because the downstream API is identical.
+
+## Run it standalone
+
+```bash
+# From sidecar/weather-api
+docker build -t weather-api:local .
+docker run --rm -p 8080:8080 \
+  -e TENANT_ID=<your-tenant-id> \
+  -e EXPECTED_AUDIENCE=https://graph.microsoft.com \
+  weather-api:local
+```
+
+Then, with an Agent Identity token from [`../../scripts/README.md`](../../scripts/README.md):
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+     "http://localhost:8080/weather?city=Dallas"
+```
+
+Expected response (real data):
+
+```json
+{
+  "city": "Dallas",
+  "temperature": 61,
+  "temperature_unit": "F",
+  "condition": "Overcast",
+  "humidity": 93,
+  "wind_speed": 8,
+  "is_agent_identity": true,
+  "agent_app_id": "<agent-app-id from xms_par_app_azp>",
+  "validated_by": "Agent Identity Token",
+  "data_source": "Open-Meteo API (Real-time)"
+}
+```
+
+## Environment variables
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `TENANT_ID` | yes | — | Entra tenant — used to build JWKS URL and issuer check |
+| `EXPECTED_AUDIENCE` | no | `https://graph.microsoft.com` | Accepted `aud` value on the token |
+| `PORT` | no | `8080` | HTTP port |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `app.py` | Flask app — route handlers, token validation, Open-Meteo client |
+| `Dockerfile` | `python:3.13-slim` base, runs `gunicorn app:app -b 0.0.0.0:8080` |
+| `requirements.txt` | `flask`, `pyjwt[crypto]`, `cryptography`, `requests`, `gunicorn` |
+
+## Why this is in the repo
+
+Token validation libraries differ between ecosystems (Python, Node, .NET). Having a *known-good* validator that the `dev` and `aws` samples both hit makes issues much easier to isolate — if both samples fail against `weather-api`, the problem is the sidecar or Entra config, not the downstream API.
+
+For the conceptual overview of how tokens flow from agent → sidecar → API, see [`../README.md`](../README.md).


### PR DESCRIPTION
# PR #7 — `razi/readme-alignment` → `dev`

## Title
`readme-alignment: scrub "Lab", retitle READMEs, add scripts/ + weather-api READMEs, TOC §4.3 ACA`

## Why
After PRs #4–#6 merged into `dev`, a pass across all 6 READMEs showed:

- Root `README.md` was a 1-line stub, not a navigation hub.
- `sidecar/README.md` was a 1250-line "Lab Guide" with 15 `Lab` mentions and a stale `./llm-agent/README.md` link.
- `sidecar/dev/README.md` had a blocking `TODO: Screenshots...` callout and a broken `../SIDECAR-GUIDE.md` link.
- `sidecar/aws/README.md` had the same broken link.
- `sidecar/weather-api/` had no README at all.
- The TOC didn't list the Azure Container Apps tutorials merged in PR #6.
- The PowerShell setup walkthrough lived under `sidecar/` even though it's *prereq* content that applies to **every** sidecar edition.

## What this PR does

### Root `README.md` — new navigation hub
Links to §1 (coming soon), §2 sidecar, §3 cross-cloud, §4 deploy — each row points at the actual file or is marked `(coming soon)` with the owner.

### `sidecar/README.md` — carved + rewritten
- 1250 → ~180 lines
- New title: **The Sidecar Design Pattern** (matches TOC §2.1)
- Preserved: architecture narrative, the two token-flow diagrams (autonomous, on-behalf-of), key-concepts table
- Removed: inline PowerShell walkthrough (moved — see next), every `Lab` word, stale `llm-agent/README.md` and `SIDECAR-GUIDE.md` links

### `scripts/README.md` — new file, receives the PowerShell walkthrough
Bootstrap and end-to-end verification walkthrough. Sections use `Walkthrough`, `You'll learn`, `Cleanup`, `Summary` — no "Lab" framing. Ties to TOC §1.2.

### `sidecar/dev/README.md` — retitled, TODO removed
- New title: **Run the Sidecar Locally — Developer Quickstart (Ollama)** (matches TOC §2.3)
- Removed blocking `> TODO: Screenshots...` callout
- Fixed `../SIDECAR-GUIDE.md` → `../README.md`

### `sidecar/aws/README.md` — retitled
- New title: **AWS: Amazon Bedrock Agent with Entra Agent ID Sidecar** (matches TOC §3.1)
- Fixed `../SIDECAR-GUIDE.md` → `../README.md`

### `sidecar/weather-api/README.md` — new file
Short README (~90 lines): purpose, endpoints, token-validation rules, env vars, standalone run instructions, why it's shared.

### `GA-CONTENT-TOC.md` — additions
- §4.3 row: **Deploy to Azure Container Apps** (owner `@razi-rais`)
- `deploy/azure/container-apps/` subtree in the repo-layout block
- `scripts/README.md` line in the `scripts/` entry

### `.gitignore` — small add
Excludes local `PR-*-DESCRIPTION.md` scratchpads.

## Verification

```
grep -cE '\bLab\b' across all changed READMEs             = 0
Stale links (SIDECAR-GUIDE.md, llm-agent/README.md)       = 0
All relative links point at files that exist              = pass
```

## Diff summary
```
 .gitignore                    |    3 +
 GA-CONTENT-TOC.md             |    6 +
 README.md                     |   75 +++
 scripts/README.md             |  225 +++++++
 sidecar/README.md             | 1305 ++++--------------
 sidecar/aws/README.md         |    4 +-
 sidecar/dev/README.md         |    6 +-
 sidecar/weather-api/README.md |   86 +++
 8 files changed, 498 insertions(+), 1212 deletions(-)
```

## Not in this PR
- `PREREQUISITES.md` (Gargi owns)
- Any code, secrets, or Azure resource changes
- `.github/skills/**` (internal tooling, keeps its voice)
- Screenshots for `sidecar/dev/docs/images/` (callout removed; images can land in a follow-up)

---
Base: `dev` · Target: `dev`
