### PR TITLE
readme: simplify root README, drop internal GA-CONTENT-TOC references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,31 @@
 # Entra Agent ID Samples
 
-Runnable samples and walkthroughs for **Microsoft Entra Agent ID** — Entra's purpose-built identity for AI agents.
+Runnable samples for **Microsoft Entra Agent ID** — Entra's purpose-built identity for AI agents.
 
-This repository shows you how to:
+## What's here
 
-- Provision a **Blueprint** application, an **Agent Identity**, and a **Client SPA** in your Entra tenant.
-- Run the **Microsoft Entra SDK auth sidecar** next to your agent so the agent code never sees a secret.
-- Mint **autonomous (app-only)** and **on-behalf-of** tokens for the agent.
-- Call a downstream API (the included `weather-api`) with a token that validates cleanly (signature, issuer, agent-identity claims).
-- Deploy the whole thing to **Azure Container Apps** with *zero stored secrets* — federated credentials only.
-
-## Start here
-
-| If you're… | Go to |
+| Folder | What it is |
 |---|---|
-| New to Entra Agent ID and want the concepts | [`sidecar/README.md`](sidecar/README.md) — the sidecar design pattern |
-| Setting up your Entra tenant for the first time | [`scripts/README.md`](scripts/README.md) — PowerShell bootstrap walkthrough |
-| Looking for the fastest runnable demo | [`sidecar/dev/README.md`](sidecar/dev/README.md) — local agent with Ollama |
-| Running against a cloud LLM | [`sidecar/aws/README.md`](sidecar/aws/README.md) — AWS Bedrock (Claude) |
-| Deploying to Azure | [`deploy/azure/container-apps/`](deploy/azure/container-apps/) |
+| [`sidecar/`](sidecar/) | Sidecar-pattern samples (agent + Entra SDK auth sidecar) with local-LLM and AWS Bedrock editions |
+| [`scripts/`](scripts/) | PowerShell + bash tooling to provision Blueprint, Agent Identity, and Client SPA in your tenant |
+| [`deploy/`](deploy/) | Deploy the samples to Azure (Container Apps today; App Service and AKS coming) |
 
-## Table of contents
+## Quick start
 
-Content is laid out per [`GA-CONTENT-TOC.md`](GA-CONTENT-TOC.md).
+1. Provision Entra objects: [`scripts/README.md`](scripts/README.md)
+2. Run a local demo: [`sidecar/dev/README.md`](sidecar/dev/README.md)
 
-### 1 · Getting started
-- **1.1** Entra Agent ID architecture and patterns *(coming soon — owner @astaykov)*
-- **1.2** [`PREREQUISITES.md`](PREREQUISITES.md) — environment setup *(coming soon — owner @Gargi-Sinha)*
+## Learn more
 
-### 2 · Sidecar pattern
-- **2.1** [The Sidecar Design Pattern](sidecar/README.md)
-- **2.2** End-to-end token flow: agent → weather API *(covered inline in §2.3 sample)*
-- **2.3** [Run the sidecar locally (developer quickstart)](sidecar/dev/README.md)
-
-### 3 · Third-party agent platforms
-
-Sidecar pattern (container-based):
-- **3.1** [AWS: Amazon Bedrock agent with Entra Agent ID sidecar](sidecar/aws/README.md)
-- **3.2** GCP: Vertex AI (Gemini) agent with Entra Agent ID sidecar *(coming soon)*
-
-Federation pattern (token exchange via FIC):
-- **3.3** GCP: Workload Identity Federation with Entra Agent ID *(coming soon — owner @ArLucaID)*
-
-Low-code:
-- **3.5** N8N: low-code agent with Entra Agent ID *(coming soon — owner @astaykov)*
-
-### 4 · Deploy
-- **4.1** Deploy to Azure App Service *(coming soon)*
-- **4.2** Deploy to Azure Kubernetes Service with Workload Identity *(coming soon — owner @yoelhor)*
-- **4.3** [Deploy to Azure Container Apps](deploy/azure/container-apps/) — AWS Bedrock and local-LLM variants
-
-## Repository layout
-
-```
-├── scripts/                   Shared PowerShell + bash bootstrap tooling
-├── sidecar/                   Sidecar pattern samples
-│   ├── weather-api/           Shared token-validated downstream API
-│   ├── dev/                   Local-LLM (Ollama) edition
-│   └── aws/                   AWS Bedrock edition
-├── deploy/                    Deployment samples
-│   └── azure/container-apps/  Azure Container Apps tutorials
-└── .github/skills/            AI-led workflow skills (optional tooling)
-```
+- [Microsoft Entra Agent ID overview](https://learn.microsoft.com/en-us/entra/agent-id/)
+- [Microsoft Entra SDK for Agent Identities](https://learn.microsoft.com/en-us/entra/agent-id/identity-platform/microsoft-entra-sdk-for-agent-identities)
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) *(coming soon)*. Content owners are listed in [`GA-CONTENT-TOC.md`](GA-CONTENT-TOC.md).
-
-Branching model: `owner/feature → PR → dev → PR → main`.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License and code of conduct
 
 - [`LICENSE`](LICENSE)
 - [`SECURITY.md`](SECURITY.md)
-- Code of Conduct: this project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+- This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,8 +9,6 @@ Shared PowerShell and bash tooling that provisions the Entra objects every sampl
 
 Run these once per tenant. After that, the IDs go into each sample's `.env` (local dev) or into federated credentials (Azure production).
 
-> TOC: these scripts back **§1.2 Prerequisites** and are referenced from the §2 and §3 samples. For the conceptual overview see [`../sidecar/README.md`](../sidecar/README.md).
-
 ## Prerequisites
 
 - **PowerShell 7.4+** (`pwsh`) on macOS, Linux, or Windows. The workflow uses `Microsoft.Graph.*` modules 2.35+.

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -2,7 +2,7 @@
 
 How the **Microsoft Entra Agent ID sidecar** lets an AI agent call downstream APIs with a secure, per-agent identity — without the agent code ever seeing a secret.
 
-This document is the conceptual overview (TOC §2.1). For runnable samples, see:
+For runnable samples, see:
 - [`dev/`](dev/README.md) — local-LLM (Ollama) edition
 - [`aws/`](aws/README.md) — AWS Bedrock (Claude) edition
 - [`weather-api/`](weather-api/README.md) — shared downstream API used by both
@@ -111,8 +111,8 @@ Both flows are demonstrated end-to-end in [`dev/`](dev/README.md) and [`aws/`](a
 └──────────────────────────────────────────────────────────────┘
 ```
 
-- **[`dev/`](dev/README.md)** — LangChain + Ollama (local), runs entirely offline via `docker-compose`. Fastest path to a working demo. Ties to TOC §2.3.
-- **[`aws/`](aws/README.md)** — LangChain + AWS Bedrock (Claude) with Azure→AWS OIDC federation via the `azure-token-refresher` companion. Ties to TOC §3.1.
+- **[`dev/`](dev/README.md)** — LangChain + Ollama (local), runs entirely offline via `docker-compose`. Fastest path to a working demo.
+- **[`aws/`](aws/README.md)** — LangChain + AWS Bedrock (Claude) with Azure→AWS OIDC federation via the `azure-token-refresher` companion.
 - **[`weather-api/`](weather-api/README.md)** — minimal token-validated mock API. RS256 signature check via JWKS, issuer and audience validation, agent-identity claim verification.
 
 For deploying any of the above to Azure, see [`../deploy/azure/container-apps/`](../deploy/azure/container-apps/) — zero stored secrets, federated credentials only.


### PR DESCRIPTION
Root README is now a conventional high-level landing page. Removed internal `GA-CONTENT-TOC.md` link and "§2.1"/"§4.3" style TOC numbering from user-facing READMEs (`README.md`, `scripts/README.md`, `sidecar/README.md`). `GA-CONTENT-TOC.md` stays in the repo for internal planning but is no longer referenced from any user-facing document.

Detailed walkthroughs continue to live inside each folder's own README.

Diff: -64/+17 lines across 3 files.