### PR TITLE
ui: point footer GitHub link to microsoft/entra-agentid-samples

### DIFF
--- a/sidecar/aws/templates/index.html
+++ b/sidecar/aws/templates/index.html
@@ -764,7 +764,7 @@
         });
     </script>
     <footer style="text-align:center; padding:16px 0 8px; color:#888; font-size:13px;">
-        <a href="https://github.com/razi-rais/3P-Agent-ID-Demo" target="_blank" style="color:#58a6ff; text-decoration:none;">
+        <a href="https://github.com/microsoft/entra-agentid-samples" target="_blank" style="color:#58a6ff; text-decoration:none;">
             &#128279; View source code on GitHub
         </a>
     </footer>

--- a/sidecar/dev/templates/index.html
+++ b/sidecar/dev/templates/index.html
@@ -733,7 +733,7 @@
         });
     </script>
     <footer style="text-align:center; padding:16px 0 8px; color:#888; font-size:13px;">
-        <a href="https://github.com/razi-rais/3P-Agent-ID-Demo" target="_blank" style="color:#58a6ff; text-decoration:none;">
+        <a href="https://github.com/microsoft/entra-agentid-samples" target="_blank" style="color:#58a6ff; text-decoration:none;">
             &#128279; View source code on GitHub
         </a>
     </footer>


### PR DESCRIPTION
Both agent UIs (sidecar/aws and sidecar/dev) had a footer "View source code on GitHub" link pointing to the original `razi-rais/3P-Agent-ID-Demo` source repo.

## Change
Update both footer links to `https://github.com/microsoft/entra-agentid-samples`.

## Diff
```
 sidecar/aws/templates/index.html | 2 +-
 sidecar/dev/templates/index.html | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

Base: `dev`