### PR TITLE
docs(aca): fix git clone URLs in Azure Container Apps tutorials

### DIFF
--- a/deploy/azure/container-apps/aws/README.md
+++ b/deploy/azure/container-apps/aws/README.md
@@ -194,8 +194,8 @@ Static credentials survive leaks (often for months). Federated tokens in this de
 Clone the sample repository. All paths in this tutorial are relative to the repository root.
 
 ```bash
-git clone https://github.com/<org>/3P-Agent-ID-Demo.git
-cd 3P-Agent-ID-Demo
+git clone https://github.com/microsoft/entra-agentid-samples.git
+cd entra-agentid-samples
 ```
 
 ## 2.5 Choose your SKUs

--- a/deploy/azure/container-apps/dev/README.md
+++ b/deploy/azure/container-apps/dev/README.md
@@ -143,8 +143,8 @@ The docker-compose version of this sample uses `BLUEPRINT_CLIENT_SECRET` because
 ### 2.3 Repository
 
 ```bash
-git clone https://github.com/<org>/3P-Agent-ID-Demo.git
-cd 3P-Agent-ID-Demo
+git clone https://github.com/microsoft/entra-agentid-samples.git
+cd entra-agentid-samples
 ```
 
 ## 2.5 Choose your SKUs


### PR DESCRIPTION
Both Azure Container Apps tutorials had a placeholder clone URL from the pre-migration draft.

## Change
```diff
-git clone https://github.com/<org>/3P-Agent-ID-Demo.git
-cd 3P-Agent-ID-Demo
+git clone https://github.com/microsoft/entra-agentid-samples.git
+cd entra-agentid-samples
```

Applied to:
- `deploy/azure/container-apps/aws/README.md`
- `deploy/azure/container-apps/dev/README.md`

Base: `dev`