### PR TITLE
docs: teardown skills, context-aware terminology, stronger AI-assisted-deploy highlighting

### DIFF
--- a/.claude/skills/deploy-agent-aca-aws/SKILL.md
+++ b/.claude/skills/deploy-agent-aca-aws/SKILL.md
@@ -52,7 +52,7 @@ Before running any `az` command that provisions resources, confirm each SKU choi
 Ask the user to confirm: tenant ID, subscription ID, AWS account ID, AWS region. Then:
 
 ```bash
-cp .github/skills/deploy-agent-aca-aws/scripts/deploy-vars.sh.template /tmp/deploy-vars.sh
+cp .claude/skills/deploy-agent-aca-aws/scripts/deploy-vars.sh.template /tmp/deploy-vars.sh
 # edit /tmp/deploy-vars.sh with the confirmed values
 source /tmp/deploy-vars.sh
 az login --tenant "$TENANT_ID" && az account set --subscription "$SUBSCRIPTION_ID"
@@ -68,7 +68,7 @@ Delegate to [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md). Capture `B
 Then configure the Blueprint for OBO using the ACA-compatible PowerShell script (the shipped `.sh` form uses a Graph filter that Agent Identity Blueprint types reject):
 
 ```bash
-pwsh -NoProfile -File .github/skills/deploy-agent-aca-aws/scripts/setup-obo-blueprint-for-aca.ps1 \
+pwsh -NoProfile -File .claude/skills/deploy-agent-aca-aws/scripts/setup-obo-blueprint-for-aca.ps1 \
   -BlueprintAppId "$BLUEPRINT_APP_ID" \
   -ClientSpaAppId "$CLIENT_SPA_APP_ID" \
   -AgentAppId "$AGENT_CLIENT_ID" \
@@ -86,8 +86,8 @@ Single Graph call — see tutorial [§7](../../../sidecar/aws/deploy-aws-bedrock
 ### Step 4 — Federate MI to AWS (chain B)
 
 ```bash
-bash .github/skills/deploy-agent-aca-aws/scripts/setup-intermediary-app.sh  # creates STS app, sets v1 tokens, adds FIC
-bash .github/skills/deploy-agent-aca-aws/scripts/setup-iam-role.sh          # OIDC provider + IAM role + Bedrock policy
+bash .claude/skills/deploy-agent-aca-aws/scripts/setup-intermediary-app.sh  # creates STS app, sets v1 tokens, adds FIC
+bash .claude/skills/deploy-agent-aca-aws/scripts/setup-iam-role.sh          # OIDC provider + IAM role + Bedrock policy
 ```
 
 Both scripts source `/tmp/deploy-vars.sh` and append `STS_APP_ID`, `STS_APP_URI`, `STS_SP_OID`, `AWS_ROLE_ARN`, `V1_OIDC_ARN`.
@@ -101,7 +101,7 @@ Tutorial [§9](../../../sidecar/aws/deploy-aws-bedrock-agent-sidecar-container-a
 ### Step 6 — Deploy the multi-container app
 
 ```bash
-envsubst < .github/skills/deploy-agent-aca-aws/scripts/containerapp.yaml.template > /tmp/containerapp.yaml
+envsubst < .claude/skills/deploy-agent-aca-aws/scripts/containerapp.yaml.template > /tmp/containerapp.yaml
 az containerapp update -g "$RG" -n "$APP_NAME" --yaml /tmp/containerapp.yaml
 ```
 
@@ -109,11 +109,11 @@ az containerapp update -g "$RG" -n "$APP_NAME" --yaml /tmp/containerapp.yaml
 
 Two things that cannot be done before deploy:
 
-1. **Add production SPA redirect URI** — `bash .github/skills/deploy-agent-aca-aws/scripts/add-spa-redirect-uri.sh`
+1. **Add deployed SPA redirect URI** — `bash .claude/skills/deploy-agent-aca-aws/scripts/add-spa-redirect-uri.sh`
 2. **Grant Agent → Graph delegated `User.Read` admin consent** (fixes `AADSTS65001` on OBO):
 
    ```bash
-   pwsh -NoProfile -File .github/skills/deploy-agent-aca-aws/scripts/grant-agent-obo-consent.ps1 \
+   pwsh -NoProfile -File .claude/skills/deploy-agent-aca-aws/scripts/grant-agent-obo-consent.ps1 \
      -AgentAppId "$AGENT_CLIENT_ID" -TenantId "$TENANT_ID"
    ```
 
@@ -128,7 +128,7 @@ Tutorial [§12](../../../sidecar/aws/deploy-aws-bedrock-agent-sidecar-container-
 If all prerequisites are in place and variables are confirmed, run:
 
 ```bash
-bash .github/skills/deploy-agent-aca-aws/scripts/deploy-aca-aws.sh
+bash .claude/skills/deploy-agent-aca-aws/scripts/deploy-aca-aws.sh
 ```
 
 This is idempotent and invokes steps 2–6 in order. Steps 0, 1, and 7 require human decisions and remain manual.

--- a/.claude/skills/deploy-agent-aca-aws/references/post-deploy-manual-steps.md
+++ b/.claude/skills/deploy-agent-aca-aws/references/post-deploy-manual-steps.md
@@ -2,9 +2,9 @@
 
 Two steps cannot be completed before the Container App exists, and two steps cannot be done via `az ad app update`. Run them after Step 6 (deploy) in the main SKILL procedure.
 
-## 1. Add the production SPA redirect URI
+## 1. Add the deployed SPA redirect URI
 
-The Client SPA app was registered with only `http://localhost:3003`. The production `https://<APP_FQDN>` must be added, or the browser MSAL popup fails with `AADSTS50011`.
+The Client SPA app was registered with only `http://localhost:3003`. The deployed `https://<APP_FQDN>` must be added, or the browser MSAL popup fails with `AADSTS50011`.
 
 `az ad app update --web-redirect-uris` does NOT modify SPA URIs — you must PATCH Graph directly:
 

--- a/.claude/skills/deploy-agent-aca-aws/references/sku-sizing.md
+++ b/.claude/skills/deploy-agent-aca-aws/references/sku-sizing.md
@@ -1,6 +1,6 @@
 # SKU and sizing decisions
 
-Before provisioning any Azure resources, confirm each of these SKU choices with the user. Do **not** silently default to the cheapest tier — the defaults below are fine for a one-shot demo but will bite you on iteration, debugging, or production use.
+Before provisioning any Azure resources, confirm each of these SKU choices with the user. Do **not** silently default to the cheapest tier — the defaults below are fine for a one-shot demo but will bite you on iteration, debugging, or real workloads.
 
 Cost estimates are approximate USD/month (East US 2, April 2026) and assume `minReplicas = 1`.
 

--- a/.claude/skills/deploy-agent-aca-dev/SKILL.md
+++ b/.claude/skills/deploy-agent-aca-dev/SKILL.md
@@ -53,7 +53,7 @@ Before running any `az` command that provisions resources, confirm each SKU choi
 Ask the user to confirm: tenant ID, subscription ID, SKU choices, Ollama model. Then:
 
 ```bash
-cp .github/skills/deploy-agent-aca-dev/scripts/deploy-vars.sh.template /tmp/deploy-vars.sh
+cp .claude/skills/deploy-agent-aca-dev/scripts/deploy-vars.sh.template /tmp/deploy-vars.sh
 # edit /tmp/deploy-vars.sh with confirmed values
 source /tmp/deploy-vars.sh
 az login --tenant "$TENANT_ID" && az account set --subscription "$SUBSCRIPTION_ID"
@@ -66,7 +66,7 @@ Delegate to [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md). Capture `B
 Configure the Blueprint for OBO using the ACA-compatible PowerShell script:
 
 ```bash
-pwsh -NoProfile -File .github/skills/deploy-agent-aca-dev/scripts/setup-obo-blueprint-for-aca.ps1 \
+pwsh -NoProfile -File .claude/skills/deploy-agent-aca-dev/scripts/setup-obo-blueprint-for-aca.ps1 \
   -BlueprintAppId "$BLUEPRINT_APP_ID" \
   -ClientSpaAppId "$CLIENT_SPA_APP_ID" \
   -AgentAppId "$AGENT_CLIENT_ID" \
@@ -90,13 +90,13 @@ Tutorial [§8](../../../sidecar/dev/deploy-local-llm-agent-sidecar-container-app
 If `OLLAMA_IMAGE_STRATEGY=baked`:
 
 ```bash
-bash .github/skills/deploy-agent-aca-dev/scripts/build-ollama-image.sh
+bash .claude/skills/deploy-agent-aca-dev/scripts/build-ollama-image.sh
 ```
 
 ### Step 5 — Deploy the multi-container app
 
 ```bash
-envsubst < .github/skills/deploy-agent-aca-dev/scripts/containerapp.yaml.template > /tmp/containerapp.yaml
+envsubst < .claude/skills/deploy-agent-aca-dev/scripts/containerapp.yaml.template > /tmp/containerapp.yaml
 az containerapp update -g "$RG" -n "$APP_NAME" --yaml /tmp/containerapp.yaml
 ```
 
@@ -104,11 +104,11 @@ az containerapp update -g "$RG" -n "$APP_NAME" --yaml /tmp/containerapp.yaml
 
 Two things that cannot be done before deploy:
 
-1. **Add production SPA redirect URI** — `bash .github/skills/deploy-agent-aca-dev/scripts/add-spa-redirect-uri.sh`
+1. **Add deployed SPA redirect URI** — `bash .claude/skills/deploy-agent-aca-dev/scripts/add-spa-redirect-uri.sh`
 2. **Grant Agent → Graph delegated `User.Read`** (fixes `AADSTS65001`):
 
    ```bash
-   pwsh -NoProfile -File .github/skills/deploy-agent-aca-dev/scripts/grant-agent-obo-consent.ps1 \
+   pwsh -NoProfile -File .claude/skills/deploy-agent-aca-dev/scripts/grant-agent-obo-consent.ps1 \
      -AgentAppId "$AGENT_CLIENT_ID" -TenantId "$TENANT_ID"
    ```
 
@@ -123,7 +123,7 @@ Tutorial [§11](../../../sidecar/dev/deploy-local-llm-agent-sidecar-container-ap
 If all prerequisites are in place and SKU variables are confirmed:
 
 ```bash
-bash .github/skills/deploy-agent-aca-dev/scripts/deploy-aca-dev.sh
+bash .claude/skills/deploy-agent-aca-dev/scripts/deploy-aca-dev.sh
 ```
 
 Idempotent. Invokes steps 2–5 in order. Steps 0, 1, 6 require human decisions and remain manual.

--- a/.claude/skills/deploy-agent-aca-dev/references/post-deploy-manual-steps.md
+++ b/.claude/skills/deploy-agent-aca-dev/references/post-deploy-manual-steps.md
@@ -2,14 +2,14 @@
 
 Two steps cannot be completed before the Container App exists, and two cannot be done via `az ad app update`. Run them after Step 5 (deploy) in the main SKILL procedure.
 
-## 1. Add the production SPA redirect URI
+## 1. Add the deployed SPA redirect URI
 
-The Client SPA app was registered with only `http://localhost:3003`. The production `https://<APP_FQDN>` must be added, or the browser MSAL popup fails with `AADSTS50011`.
+The Client SPA app was registered with only `http://localhost:3003`. The deployed `https://<APP_FQDN>` must be added, or the browser MSAL popup fails with `AADSTS50011`.
 
 `az ad app update --web-redirect-uris` does NOT modify SPA URIs — you must PATCH Graph directly:
 
 ```bash
-bash .github/skills/deploy-agent-aca-dev/scripts/add-spa-redirect-uri.sh
+bash .claude/skills/deploy-agent-aca-dev/scripts/add-spa-redirect-uri.sh
 ```
 
 Idempotent — fetches existing `spa.redirectUris`, appends `https://$APP_FQDN`, PATCHes back.
@@ -33,7 +33,7 @@ AADSTS65001: The user or administrator has not consented to use the application
 ### Fix
 
 ```powershell
-pwsh -NoProfile -File .github/skills/deploy-agent-aca-dev/scripts/grant-agent-obo-consent.ps1 \
+pwsh -NoProfile -File .claude/skills/deploy-agent-aca-dev/scripts/grant-agent-obo-consent.ps1 \
   -AgentAppId "$AGENT_CLIENT_ID" -TenantId "$TENANT_ID"
 ```
 

--- a/.claude/skills/deploy-agent-aca-dev/references/sku-sizing.md
+++ b/.claude/skills/deploy-agent-aca-dev/references/sku-sizing.md
@@ -1,6 +1,6 @@
 # SKU and sizing decisions
 
-Before provisioning any Azure resources, confirm each of these SKU choices with the user. Do **not** silently default to the cheapest tier. The defaults are fine for a one-shot demo but bite you on iteration, debugging, or production use.
+Before provisioning any Azure resources, confirm each of these SKU choices with the user. Do **not** silently default to the cheapest tier. The defaults are fine for a one-shot demo but bite you on iteration, debugging, or real workloads.
 
 Cost estimates are approximate USD/month (East US 2, April 2026) and assume `minReplicas = 1`.
 

--- a/.claude/skills/entra-agent-id-setup/references/permissions.md
+++ b/.claude/skills/entra-agent-id-setup/references/permissions.md
@@ -7,7 +7,7 @@ Per [Microsoft Learn — Agent 365 AI-guided setup](https://learn.microsoft.com/
 | Role | Template ID | Scope | Notes |
 |------|-------------|-------|-------|
 | Global Administrator | `62e90394-69f5-4237-9190-012177145e10` | All | Least-specific; highest privilege |
-| Agent ID Administrator | `db506228-d27e-4b7d-95e5-295956d6615f` | Agent ID-specific | **Recommended** for production setup. Full blueprint / agent / agentic-user lifecycle |
+| Agent ID Administrator | `db506228-d27e-4b7d-95e5-295956d6615f` | Agent ID-specific | **Recommended** for shared-tenant setup. Full blueprint / agent / agentic-user lifecycle |
 | Agent ID Developer | `adb2368d-a9be-41b5-8667-d96778e081b0` | Agent ID-specific | **Least-privileged that works — empirically verified 2026-04-21**. Per Learn: *"Create an agent blueprint and its service principal in a tenant. User will be added as an owner."* |
 
 ### Roles that DO NOT work

--- a/.claude/skills/teardown-agent-aca-aws/SKILL.md
+++ b/.claude/skills/teardown-agent-aca-aws/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: teardown-agent-aca-aws
+description: 'AI-led teardown of the AWS Bedrock sample agent deployment on Azure Container Apps created by deploy-agent-aca-aws. Use when the user wants to delete the AWS sample ACA deployment, clean up the resource group, remove the AWS IAM role + OIDC provider, delete the intermediary Entra app, or optionally delete the Blueprint / Agent Identity / Client SPA. Defaults to DRY-RUN and keeps Entra/AWS objects unless the user explicitly opts in. NOT for local docker-compose (no cloud resources to delete) and NOT for GCP (pending).'
+---
+
+# Teardown — AWS Bedrock Agent on Azure Container Apps (AI-Led)
+
+Reverses the `deploy-agent-aca-aws` skill. Deletes Azure resources, the AWS IAM role and OIDC provider, and (opt-in) the Entra objects created along the way.
+
+**Paired with:** [deploy-agent-aca-aws](../deploy-agent-aca-aws/SKILL.md). Uses the same `/tmp/deploy-vars.sh` produced by that skill.
+
+## When to Use
+
+- User says: "tear down the AWS ACA deployment", "delete the Azure resources for the AWS sample", "clean up after the demo"
+- User wants to re-run the deploy skill from a clean state
+- User is ending a demo and needs to remove billable resources
+
+## Do NOT Use When
+
+- **Local dev** — `sidecar/dev/` runs in docker-compose; `docker compose down -v` is enough
+- **Shared / long-lived tenants** — do not run this against a tenant where other teams may own the Blueprint or Client SPA. Confirm ownership with the user first.
+- **Hardened / long-lived deployments** — this skill assumes a throwaway demo deployment.
+
+## Safety posture
+
+This skill is destructive. To prevent accidents:
+
+1. **Dry-run by default.** Every script defaults to `DRY_RUN=1` — it prints the commands it would run and exits. The user must explicitly set `DRY_RUN=0` to actually delete.
+2. **Entra and AWS objects are opt-in.** Default behavior deletes only the Azure resource group. Entra apps (Agent Identity, Blueprint, Client SPA, Intermediary) and AWS objects (IAM role, OIDC provider) are preserved unless the user sets `DELETE_ENTRA=1` or `DELETE_AWS=1`.
+3. **Confirm the tenant + subscription + resource group** with the user before running anything. The user has multiple Azure accounts (see user memory).
+4. **Never auto-delete Blueprints** — Blueprints may be shared across agents. If `DELETE_ENTRA=1`, ask the user one more time: "Delete Blueprint `<id>`? y/N".
+
+## Prerequisites
+
+- `/tmp/deploy-vars.sh` from the original deployment (contains `RG`, `STS_APP_ID`, `AWS_ROLE_NAME`, `AWS_ACCOUNT_ID`, `TENANT_ID`, etc.). If missing, reconstruct the minimum set with the user (at least `SUBSCRIPTION_ID`, `RG`).
+- `az` logged in to the same tenant and subscription that owns the RG.
+- `aws` configured for the same account that owns the role (only if `DELETE_AWS=1`).
+- Graph role sufficient to delete Entra apps (only if `DELETE_ENTRA=1`): `Application Administrator` or higher.
+
+## Procedure
+
+### Step 0 — Confirm scope with the user
+
+Print the current settings and wait for explicit confirmation:
+
+```
+Teardown plan (AWS):
+  Subscription:  $SUBSCRIPTION_ID
+  Resource group: $RG            (WILL be deleted)
+  Delete AWS IAM role + OIDC:  $DELETE_AWS
+  Delete Entra objects:         $DELETE_ENTRA
+  Dry run:                      $DRY_RUN
+Proceed? [y/N]
+```
+
+Do not proceed without a `y`.
+
+### Step 1 — Revoke OAuth consent grants on the Agent SP (optional but recommended)
+
+If the Agent Identity (`AGENT_CLIENT_ID`) will be kept, revoke the Graph OAuth2 consent so a future redeploy starts from a clean state:
+
+```bash
+AGENT_SP_OID=$(az ad sp show --id "$AGENT_CLIENT_ID" --query id -o tsv 2>/dev/null)
+if [[ -n "$AGENT_SP_OID" ]]; then
+  az rest --method GET \
+    --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants?\$filter=clientId eq '$AGENT_SP_OID'" \
+    --query 'value[].id' -o tsv | while read -r g; do
+      az rest --method DELETE --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants/$g"
+  done
+fi
+```
+
+This is idempotent — if the SP or the grants are gone already, it no-ops.
+
+### Step 2 — Delete the Azure resource group
+
+This removes the Container App, ACA environment, ACR (with all images), Log Analytics workspace, and the user-assigned managed identity in one shot:
+
+```bash
+az group delete --name "$RG" --yes --no-wait
+```
+
+**Note:** FICs on the Blueprint and Intermediary Entra apps that point at the deleted MI's object ID become orphaned but inert. They are cleaned up in Step 4 if `DELETE_ENTRA=1`, or can be left in place — they cannot be re-used since the MI they reference no longer exists.
+
+### Step 3 — Delete AWS objects (opt-in: `DELETE_AWS=1`)
+
+```bash
+aws iam delete-role-policy --role-name "$AWS_ROLE_NAME" --policy-name BedrockInvokeOnly 2>/dev/null || true
+aws iam delete-role --role-name "$AWS_ROLE_NAME" 2>/dev/null || true
+aws iam delete-open-id-connect-provider \
+  --open-id-connect-provider-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/sts.windows.net/${TENANT_ID}/" 2>/dev/null || true
+```
+
+### Step 4 — Delete Entra objects (opt-in: `DELETE_ENTRA=1`)
+
+Ask the user once more per object. Delete in this order to avoid broken references:
+
+1. **Intermediary app** (`STS_APP_ID`) — safe to delete, created purely for AWS federation.
+2. **Client SPA** (`CLIENT_SPA_APP_ID`) — safe if no other agent reuses it.
+3. **Agent Identity** — delete via Agent ID portal or Graph (`DELETE /agentIdentities/{id}`).
+4. **Blueprint** (`BLUEPRINT_APP_ID`) — **ASK AGAIN**. Blueprints are often shared.
+
+```bash
+az ad app delete --id "$STS_APP_ID" 2>/dev/null || true
+az ad app delete --id "$CLIENT_SPA_APP_ID" 2>/dev/null || true
+# Agent + Blueprint: prompt explicitly, then call Graph
+```
+
+### Step 5 — Verify
+
+```bash
+az group exists --name "$RG"                                          # expect: false
+aws iam get-role --role-name "$AWS_ROLE_NAME" 2>&1 | head -1          # expect: NoSuchEntity (if DELETE_AWS=1)
+az ad app show --id "$STS_APP_ID" 2>&1 | head -1                      # expect: not found (if DELETE_ENTRA=1)
+```
+
+## Orchestrator
+
+The single-entry-point script is [`scripts/teardown-aca-aws.sh`](./scripts/teardown-aca-aws.sh). It reads `/tmp/deploy-vars.sh`, enforces dry-run by default, prompts at every destructive boundary, and executes steps 1–5 in order.
+
+```bash
+# Dry run (default)
+bash .claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
+
+# Real teardown, Azure only
+DRY_RUN=0 bash .claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
+
+# Full teardown
+DRY_RUN=0 DELETE_AWS=1 DELETE_ENTRA=1 \
+  bash .claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
+```
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `az group delete` hangs on soft-deleted Key Vault | RG contained a KV with purge protection | Purge separately: `az keyvault purge --name <kv>` |
+| `DeleteConflict` on IAM role | Role still attached to an instance profile or has inline policies | The script deletes `BedrockInvokeOnly` first; if extra policies exist, list + detach them manually |
+| `Authorization_RequestDenied` on `az ad app delete` | Signing-in user lacks `Application Administrator` on the app | Have the app owner run it, or elevate via PIM |
+| FIC cleanup leaves orphaned entries on Blueprint | MI already deleted by `az group delete` | Inert — delete via `az ad app federated-credential list/delete` if cosmetic cleanup matters |
+| OIDC provider already in use by another role | Shared across multiple role bindings in the same account | Do NOT delete the OIDC provider; leave `DELETE_AWS=0` or delete only the role |
+
+## References
+
+- [Azure — delete resource group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/delete-resource-group)
+- [AWS IAM — delete OIDC identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_manage-oidc.html)
+- [Microsoft Graph — oauth2PermissionGrants](https://learn.microsoft.com/en-us/graph/api/oauth2permissiongrant-delete)

--- a/.claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
+++ b/.claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Teardown orchestrator for deploy-agent-aca-aws.
+# Safe by default: DRY_RUN=1, DELETE_AWS=0, DELETE_ENTRA=0.
+#
+# Usage:
+#   bash teardown-aca-aws.sh                                  # dry-run, Azure only
+#   DRY_RUN=0 bash teardown-aca-aws.sh                        # real, Azure only
+#   DRY_RUN=0 DELETE_AWS=1 DELETE_ENTRA=1 bash teardown-aca-aws.sh   # full
+
+set -u
+set -o pipefail
+
+: "${VARS_FILE:=/tmp/deploy-vars.sh}"
+: "${DRY_RUN:=1}"
+: "${DELETE_AWS:=0}"
+: "${DELETE_ENTRA:=0}"
+
+if [[ -f "$VARS_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$VARS_FILE"
+else
+  echo "ERROR: $VARS_FILE not found. Re-export SUBSCRIPTION_ID, TENANT_ID, RG (and AWS_* / STS_APP_ID / CLIENT_SPA_APP_ID if deleting those)." >&2
+  exit 1
+fi
+
+: "${SUBSCRIPTION_ID:?SUBSCRIPTION_ID required in $VARS_FILE}"
+: "${RG:?RG required in $VARS_FILE}"
+
+run() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY-RUN: $*"
+  else
+    echo "+ $*"
+    eval "$@"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY-RUN: would prompt '$prompt' — assuming yes"
+    return 0
+  fi
+  read -r -p "$prompt [y/N] " ans
+  [[ "$ans" == "y" || "$ans" == "Y" ]]
+}
+
+echo "=============================================="
+echo "Teardown plan (AWS ACA deployment)"
+echo "  Tenant:          ${TENANT_ID:-<unset>}"
+echo "  Subscription:    $SUBSCRIPTION_ID"
+echo "  Resource group:  $RG   (WILL be deleted)"
+echo "  Delete AWS:      $DELETE_AWS  (IAM role + OIDC provider)"
+echo "  Delete Entra:    $DELETE_ENTRA (Intermediary, Client SPA, Agent, Blueprint)"
+echo "  Dry run:         $DRY_RUN"
+echo "=============================================="
+confirm "Proceed?" || { echo "Aborted."; exit 0; }
+
+run "az account set --subscription '$SUBSCRIPTION_ID'"
+
+# -- Step 1: revoke OAuth grants on Agent SP (keeps Agent reusable) --
+if [[ -n "${AGENT_CLIENT_ID:-}" ]]; then
+  echo ""
+  echo "Step 1 — Revoke OAuth consent grants on Agent SP ($AGENT_CLIENT_ID)"
+  AGENT_SP_OID=$(az ad sp show --id "$AGENT_CLIENT_ID" --query id -o tsv 2>/dev/null || true)
+  if [[ -n "$AGENT_SP_OID" ]]; then
+    GRANTS=$(az rest --method GET \
+      --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants?\$filter=clientId eq '$AGENT_SP_OID'" \
+      --query 'value[].id' -o tsv 2>/dev/null || true)
+    if [[ -n "$GRANTS" ]]; then
+      while IFS= read -r g; do
+        [[ -n "$g" ]] && run "az rest --method DELETE --uri 'https://graph.microsoft.com/v1.0/oauth2PermissionGrants/$g'"
+      done <<< "$GRANTS"
+    else
+      echo "  (no grants found)"
+    fi
+  else
+    echo "  (Agent SP not found — skipping)"
+  fi
+fi
+
+# -- Step 2: delete the RG (ACA + ACR + Log Analytics + MI) --
+echo ""
+echo "Step 2 — Delete resource group $RG"
+if az group show --name "$RG" >/dev/null 2>&1; then
+  run "az group delete --name '$RG' --yes --no-wait"
+else
+  echo "  (RG does not exist — skipping)"
+fi
+
+# -- Step 3: AWS cleanup (opt-in) --
+if [[ "$DELETE_AWS" == "1" ]]; then
+  echo ""
+  echo "Step 3 — Delete AWS IAM role + OIDC provider"
+  : "${AWS_ROLE_NAME:?AWS_ROLE_NAME required when DELETE_AWS=1}"
+  : "${AWS_ACCOUNT_ID:?AWS_ACCOUNT_ID required when DELETE_AWS=1}"
+  : "${TENANT_ID:?TENANT_ID required when DELETE_AWS=1}"
+  confirm "Delete IAM role '$AWS_ROLE_NAME'?" && {
+    run "aws iam delete-role-policy --role-name '$AWS_ROLE_NAME' --policy-name BedrockInvokeOnly 2>/dev/null || true"
+    run "aws iam delete-role --role-name '$AWS_ROLE_NAME' 2>/dev/null || true"
+  }
+  OIDC_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/sts.windows.net/${TENANT_ID}/"
+  confirm "Delete OIDC provider '$OIDC_ARN'? (skip if other roles use it)" && {
+    run "aws iam delete-open-id-connect-provider --open-id-connect-provider-arn '$OIDC_ARN' 2>/dev/null || true"
+  }
+else
+  echo ""
+  echo "Step 3 — Skipping AWS cleanup (DELETE_AWS=0)"
+fi
+
+# -- Step 4: Entra cleanup (opt-in) --
+if [[ "$DELETE_ENTRA" == "1" ]]; then
+  echo ""
+  echo "Step 4 — Delete Entra objects"
+  if [[ -n "${STS_APP_ID:-}" ]] && confirm "Delete Intermediary app (STS_APP_ID=$STS_APP_ID)?"; then
+    run "az ad app delete --id '$STS_APP_ID' 2>/dev/null || true"
+  fi
+  if [[ -n "${CLIENT_SPA_APP_ID:-}" ]] && confirm "Delete Client SPA (CLIENT_SPA_APP_ID=$CLIENT_SPA_APP_ID)?"; then
+    run "az ad app delete --id '$CLIENT_SPA_APP_ID' 2>/dev/null || true"
+  fi
+  if [[ -n "${AGENT_CLIENT_ID:-}" ]] && confirm "Delete Agent Identity (AGENT_CLIENT_ID=$AGENT_CLIENT_ID)?"; then
+    echo "  NOTE: delete the Agent Identity via the Agent ID portal or Graph:"
+    echo "    az rest --method DELETE --uri 'https://graph.microsoft.com/beta/agentIdentities/$AGENT_CLIENT_ID'"
+  fi
+  if [[ -n "${BLUEPRINT_APP_ID:-}" ]]; then
+    echo ""
+    echo "  *** Blueprint ($BLUEPRINT_APP_ID) is often SHARED across agents. ***"
+    if confirm "Are you SURE you want to delete the Blueprint?"; then
+      run "az ad app delete --id '$BLUEPRINT_APP_ID' 2>/dev/null || true"
+    fi
+  fi
+else
+  echo ""
+  echo "Step 4 — Skipping Entra cleanup (DELETE_ENTRA=0)"
+fi
+
+# -- Step 5: verify --
+echo ""
+echo "Step 5 — Verify"
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "DRY-RUN: skipping verification"
+else
+  echo "  RG exists?  $(az group exists --name "$RG")"
+  [[ "$DELETE_AWS" == "1" && -n "${AWS_ROLE_NAME:-}" ]] && \
+    echo "  IAM role:   $(aws iam get-role --role-name "$AWS_ROLE_NAME" 2>&1 | head -1)"
+  [[ "$DELETE_ENTRA" == "1" && -n "${STS_APP_ID:-}" ]] && \
+    echo "  STS app:    $(az ad app show --id "$STS_APP_ID" 2>&1 | head -1)"
+fi
+
+echo ""
+echo "Done. If DRY_RUN=1, re-run with DRY_RUN=0 to actually delete."

--- a/.claude/skills/teardown-agent-aca-dev/SKILL.md
+++ b/.claude/skills/teardown-agent-aca-dev/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: teardown-agent-aca-dev
+description: 'AI-led teardown of the local-LLM (Ollama) sample agent deployment on Azure Container Apps created by deploy-agent-aca-dev. Use when the user wants to delete the dev sample ACA deployment, clean up the resource group, or optionally delete the Blueprint / Agent Identity / Client SPA. Defaults to DRY-RUN and keeps Entra objects unless the user explicitly opts in. NOT for local docker-compose (use `docker compose down -v`) and NOT for the AWS Bedrock variant (use teardown-agent-aca-aws).'
+---
+
+# Teardown — Dev (Ollama) Agent on Azure Container Apps (AI-Led)
+
+Reverses the `deploy-agent-aca-dev` skill. Deletes the Azure resource group and (opt-in) the Entra objects.
+
+**Paired with:** [deploy-agent-aca-dev](../deploy-agent-aca-dev/SKILL.md). Uses the same `/tmp/deploy-vars.sh`.
+
+## When to Use
+
+- User says: "tear down the dev ACA deployment", "delete the Ollama agent on Azure", "clean up the demo RG"
+- User wants to re-run the deploy skill from a clean state
+- User is ending a demo and needs to remove billable resources (ACA, ACR with Ollama images, Log Analytics)
+
+## Do NOT Use When
+
+- **Local docker-compose** — `cd sidecar/dev && docker compose down -v` is enough
+- **AWS variant** — use [teardown-agent-aca-aws](../teardown-agent-aca-aws/SKILL.md) (handles IAM role, OIDC provider, intermediary app)
+- **Shared / long-lived tenants** — confirm the Blueprint and Client SPA are not shared with other agents first
+
+## Safety posture
+
+1. **Dry-run by default** (`DRY_RUN=1`). User must set `DRY_RUN=0` to actually delete.
+2. **Entra objects are opt-in** (`DELETE_ENTRA=1`). Default keeps them.
+3. **Confirm tenant + subscription + RG** with the user first — the user has multiple Azure accounts.
+4. **Re-confirm before deleting the Blueprint.** Blueprints are often shared.
+
+## Prerequisites
+
+- `/tmp/deploy-vars.sh` from the original deployment (at minimum `SUBSCRIPTION_ID`, `RG`).
+- `az` logged in to the correct tenant + subscription.
+- Graph role sufficient to delete Entra apps (only if `DELETE_ENTRA=1`): `Application Administrator` or higher.
+
+## Procedure
+
+### Step 0 — Confirm scope
+
+```
+Teardown plan (dev / Ollama):
+  Subscription:  $SUBSCRIPTION_ID
+  Resource group: $RG            (WILL be deleted)
+  Delete Entra objects: $DELETE_ENTRA
+  Dry run:              $DRY_RUN
+Proceed? [y/N]
+```
+
+### Step 1 — Revoke OAuth consent grants on the Agent SP
+
+If keeping the Agent Identity, revoke existing consent so a redeploy starts clean:
+
+```bash
+AGENT_SP_OID=$(az ad sp show --id "$AGENT_CLIENT_ID" --query id -o tsv 2>/dev/null)
+if [[ -n "$AGENT_SP_OID" ]]; then
+  az rest --method GET \
+    --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants?\$filter=clientId eq '$AGENT_SP_OID'" \
+    --query 'value[].id' -o tsv | while read -r g; do
+      az rest --method DELETE --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants/$g"
+  done
+fi
+```
+
+### Step 2 — Delete the resource group
+
+```bash
+az group delete --name "$RG" --yes --no-wait
+```
+
+This removes the Container App, ACA environment, ACR (with the ~1–4 GB baked Ollama image), Log Analytics workspace, and user-assigned managed identity in one shot.
+
+### Step 3 — Delete Entra objects (opt-in: `DELETE_ENTRA=1`)
+
+Ask per object. Order:
+
+1. **Client SPA** (`CLIENT_SPA_APP_ID`) — safe if no other agent reuses it.
+2. **Agent Identity** — delete via Agent ID portal or Graph (`DELETE /agentIdentities/{id}`).
+3. **Blueprint** (`BLUEPRINT_APP_ID`) — **ASK AGAIN**. Blueprints are often shared.
+
+```bash
+az ad app delete --id "$CLIENT_SPA_APP_ID" 2>/dev/null || true
+# Agent + Blueprint: prompt explicitly, then call Graph
+```
+
+### Step 4 — Verify
+
+```bash
+az group exists --name "$RG"                          # expect: false
+az ad app show --id "$CLIENT_SPA_APP_ID" 2>&1 | head -1   # expect: not found (if DELETE_ENTRA=1)
+```
+
+## Orchestrator
+
+Single-entry-point script: [`scripts/teardown-aca-dev.sh`](./scripts/teardown-aca-dev.sh).
+
+```bash
+# Dry run (default)
+bash .claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
+
+# Real teardown, Azure only
+DRY_RUN=0 bash .claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
+
+# Full teardown (incl. Entra apps)
+DRY_RUN=0 DELETE_ENTRA=1 \
+  bash .claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
+```
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `az group delete` hangs | ACR still has replications or a KV with purge protection is in the RG | Check RG contents with `az resource list -g "$RG"`; delete the stuck resource manually |
+| `Authorization_RequestDenied` on `az ad app delete` | Signing-in user lacks `Application Administrator` on the app | Elevate via PIM or have the app owner run it |
+| FIC cleanup leaves orphaned entries on Blueprint | MI deleted by `az group delete` | Inert; clean with `az ad app federated-credential list/delete` if cosmetic |
+| Baked Ollama image still billing after `az group delete` completes | ACR has a soft-delete retention window | Check: `az acr list --query "[].{n:name,p:properties.policies.softDeletePolicy.status}"`; purge if present |
+
+## References
+
+- [Azure — delete resource group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/delete-resource-group)
+- [Microsoft Graph — oauth2PermissionGrants](https://learn.microsoft.com/en-us/graph/api/oauth2permissiongrant-delete)

--- a/.claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
+++ b/.claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Teardown orchestrator for deploy-agent-aca-dev.
+# Safe by default: DRY_RUN=1, DELETE_ENTRA=0.
+#
+# Usage:
+#   bash teardown-aca-dev.sh                              # dry-run, Azure only
+#   DRY_RUN=0 bash teardown-aca-dev.sh                    # real, Azure only
+#   DRY_RUN=0 DELETE_ENTRA=1 bash teardown-aca-dev.sh     # full
+
+set -u
+set -o pipefail
+
+: "${VARS_FILE:=/tmp/deploy-vars.sh}"
+: "${DRY_RUN:=1}"
+: "${DELETE_ENTRA:=0}"
+
+if [[ -f "$VARS_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$VARS_FILE"
+else
+  echo "ERROR: $VARS_FILE not found. Re-export SUBSCRIPTION_ID, TENANT_ID, RG (and CLIENT_SPA_APP_ID / AGENT_CLIENT_ID / BLUEPRINT_APP_ID if deleting those)." >&2
+  exit 1
+fi
+
+: "${SUBSCRIPTION_ID:?SUBSCRIPTION_ID required in $VARS_FILE}"
+: "${RG:?RG required in $VARS_FILE}"
+
+run() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY-RUN: $*"
+  else
+    echo "+ $*"
+    eval "$@"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY-RUN: would prompt '$prompt' — assuming yes"
+    return 0
+  fi
+  read -r -p "$prompt [y/N] " ans
+  [[ "$ans" == "y" || "$ans" == "Y" ]]
+}
+
+echo "=============================================="
+echo "Teardown plan (dev / Ollama ACA deployment)"
+echo "  Tenant:          ${TENANT_ID:-<unset>}"
+echo "  Subscription:    $SUBSCRIPTION_ID"
+echo "  Resource group:  $RG   (WILL be deleted)"
+echo "  Delete Entra:    $DELETE_ENTRA (Client SPA, Agent, Blueprint)"
+echo "  Dry run:         $DRY_RUN"
+echo "=============================================="
+confirm "Proceed?" || { echo "Aborted."; exit 0; }
+
+run "az account set --subscription '$SUBSCRIPTION_ID'"
+
+# -- Step 1: revoke OAuth grants on Agent SP --
+if [[ -n "${AGENT_CLIENT_ID:-}" ]]; then
+  echo ""
+  echo "Step 1 — Revoke OAuth consent grants on Agent SP ($AGENT_CLIENT_ID)"
+  AGENT_SP_OID=$(az ad sp show --id "$AGENT_CLIENT_ID" --query id -o tsv 2>/dev/null || true)
+  if [[ -n "$AGENT_SP_OID" ]]; then
+    GRANTS=$(az rest --method GET \
+      --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants?\$filter=clientId eq '$AGENT_SP_OID'" \
+      --query 'value[].id' -o tsv 2>/dev/null || true)
+    if [[ -n "$GRANTS" ]]; then
+      while IFS= read -r g; do
+        [[ -n "$g" ]] && run "az rest --method DELETE --uri 'https://graph.microsoft.com/v1.0/oauth2PermissionGrants/$g'"
+      done <<< "$GRANTS"
+    else
+      echo "  (no grants found)"
+    fi
+  else
+    echo "  (Agent SP not found — skipping)"
+  fi
+fi
+
+# -- Step 2: delete the RG --
+echo ""
+echo "Step 2 — Delete resource group $RG"
+if az group show --name "$RG" >/dev/null 2>&1; then
+  run "az group delete --name '$RG' --yes --no-wait"
+else
+  echo "  (RG does not exist — skipping)"
+fi
+
+# -- Step 3: Entra cleanup (opt-in) --
+if [[ "$DELETE_ENTRA" == "1" ]]; then
+  echo ""
+  echo "Step 3 — Delete Entra objects"
+  if [[ -n "${CLIENT_SPA_APP_ID:-}" ]] && confirm "Delete Client SPA (CLIENT_SPA_APP_ID=$CLIENT_SPA_APP_ID)?"; then
+    run "az ad app delete --id '$CLIENT_SPA_APP_ID' 2>/dev/null || true"
+  fi
+  if [[ -n "${AGENT_CLIENT_ID:-}" ]] && confirm "Delete Agent Identity (AGENT_CLIENT_ID=$AGENT_CLIENT_ID)?"; then
+    echo "  NOTE: delete the Agent Identity via the Agent ID portal or Graph:"
+    echo "    az rest --method DELETE --uri 'https://graph.microsoft.com/beta/agentIdentities/$AGENT_CLIENT_ID'"
+  fi
+  if [[ -n "${BLUEPRINT_APP_ID:-}" ]]; then
+    echo ""
+    echo "  *** Blueprint ($BLUEPRINT_APP_ID) is often SHARED across agents. ***"
+    if confirm "Are you SURE you want to delete the Blueprint?"; then
+      run "az ad app delete --id '$BLUEPRINT_APP_ID' 2>/dev/null || true"
+    fi
+  fi
+else
+  echo ""
+  echo "Step 3 — Skipping Entra cleanup (DELETE_ENTRA=0)"
+fi
+
+# -- Step 4: verify --
+echo ""
+echo "Step 4 — Verify"
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "DRY-RUN: skipping verification"
+else
+  echo "  RG exists?       $(az group exists --name "$RG")"
+  [[ "$DELETE_ENTRA" == "1" && -n "${CLIENT_SPA_APP_ID:-}" ]] && \
+    echo "  Client SPA:      $(az ad app show --id "$CLIENT_SPA_APP_ID" 2>&1 | head -1)"
+fi
+
+echo ""
+echo "Done. If DRY_RUN=1, re-run with DRY_RUN=0 to actually delete."

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Runnable samples for **Microsoft Entra Agent ID** — Entra's purpose-built iden
 
 1. Provision Entra objects: [`scripts/README.md`](scripts/README.md)
 2. Run a local demo: [`sidecar/dev/README.md`](sidecar/dev/README.md)
+3. Deploy to Azure Container Apps: [`deploy/azure/container-apps/dev/README.md`](deploy/azure/container-apps/dev/README.md) (local-LLM) or [`deploy/azure/container-apps/aws/README.md`](deploy/azure/container-apps/aws/README.md) (AWS Bedrock)
+
+> [!TIP]
+> **Deploying to Azure is much faster with an AI assistant.** Each Azure deployment tutorial ships with a paired skill under [`.claude/skills/`](.claude/skills/) that works with **Claude Code** and **GitHub Copilot Chat**. The assistant walks through SKU choices, federation wiring, and post-deploy manual steps — typically cutting a multi-hour manual deploy down to minutes.
 
 ## Learn more
 

--- a/deploy/azure/container-apps/aws/README.md
+++ b/deploy/azure/container-apps/aws/README.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial: Deploy an AWS Bedrock agent with the Microsoft Entra Agent ID sidecar on Azure Container Apps"
-description: Deploy a production AWS Bedrock agent to Azure Container Apps. The agent authenticates to Microsoft Entra through the Agent ID sidecar and to AWS STS through workload identity federation, with no stored secrets.
+description: Deploy an AWS Bedrock agent to Azure Container Apps. The agent authenticates to Microsoft Entra through the Agent ID sidecar and to AWS STS through workload identity federation, with no stored secrets.
 ms.topic: tutorial
 ms.date: 04/22/2026
 ---
@@ -19,9 +19,9 @@ In this tutorial, you learn how to:
 > * Verify the autonomous and on-behalf-of (OBO) identity flows end to end.
 
 > [!TIP]
-> **Recommended approach: AI-assisted setup.** This tutorial has many prerequisites and moving parts — Entra role assignments, Bedrock model enablement, ACR image builds, the v1 token-exchange intermediary app, and post-deploy manual wiring. Running it end-to-end by hand is fully supported (every command is documented below), but the fastest and least error-prone path is to **pair an AI assistant with the skill packaged in this repo**: [`.claude/skills/deploy-agent-aca-aws/SKILL.md`](../../../.claude/skills/deploy-agent-aca-aws/SKILL.md).
+> **Recommended: AI-assisted deployment.** The fastest, least error-prone way to finish this tutorial is to pair an AI assistant with the skill packaged in this repo: [`.claude/skills/deploy-agent-aca-aws/SKILL.md`](../../../.claude/skills/deploy-agent-aca-aws/SKILL.md). The assistant confirms your SKU choices, wires the v1 token exchange, handles the post-deploy manual steps, and surfaces known failure modes in real time — typically cutting deployment time from hours to minutes. Running the tutorial end-to-end by hand is fully supported (every command is documented below); the skill just front-loads the decisions.
 >
-> The skill works with **Claude Code** (which reads `.claude/skills/` by default) and with **GitHub Copilot Chat** (ask it to read the `SKILL.md` file). The assistant confirms your SKU choices, wires the v1 token exchange, handles the post-deploy manual steps, and surfaces known failure modes in real time. If you prefer a manual run, continue reading — the tutorial remains the source of truth.
+> The skill works with **Claude Code** (which reads `.claude/skills/` by default) and with **GitHub Copilot Chat** (ask it to read the `SKILL.md` file). If you prefer a manual run, continue reading — the tutorial remains the source of truth.
 
 ## 1. Overview
 
@@ -33,7 +33,7 @@ A single Azure Container App that exposes a browser UI at `https://<app>.<region
 |---|---|---|
 | `llm-agent` | `agent-id-aws/llm-agent` (your ACR) | Public-facing Flask + LangChain agent. Receives user chat requests on port **3000**, decides when to call a tool, uses `boto3` to call **AWS Bedrock** for LLM completions, and calls `weather-api` for downstream data. Uses `AWS_WEB_IDENTITY_TOKEN_FILE=/azure-token/token` so `boto3` federates to AWS automatically. |
 | `sidecar` | `mcr.microsoft.com/entra-sdk/auth-sidecar` (Microsoft) | The **Microsoft Entra Agent ID auth sidecar**. Listens on `localhost:5000` (not exposed externally). `llm-agent` calls it to get Agent Identity tokens — app-only (**TR**, autonomous flow) or on-behalf-of a user (**TU**, OBO flow). Authenticates to Entra as the Blueprint app using `SignedAssertionFromManagedIdentity` — no client secret. |
-| `weather-api` | `agent-id-aws/weather-api` (your ACR) | Sample downstream API on `localhost:8080`. Validates the Agent Identity JWT on every request (JWKS signature check, issuer, audience, `appid`) and returns real Open-Meteo data only if the call is from the expected Agent Identity. Demonstrates how a production downstream service should authorize agent calls. |
+| `weather-api` | `agent-id-aws/weather-api` (your ACR) | Sample downstream API on `localhost:8080`. Validates the Agent Identity JWT on every request (JWKS signature check, issuer, audience, `appid`) and returns real Open-Meteo data only if the call is from the expected Agent Identity. Demonstrates how a hardened downstream service should authorize agent calls. |
 | `token-refresher` | `agent-id-aws/token-refresher` (your ACR) | Background worker, no ports. Every ~50 minutes: reads the Container App's managed-identity assertion from IMDS, exchanges it at Entra's `/oauth2/v2.0/token` endpoint for a v1 JWT that AWS STS accepts, and writes the JWT to `/azure-token/token`. `boto3` in `llm-agent` reads this file whenever it calls `AssumeRoleWithWebIdentity`. |
 
 **Why four containers and not one.** The Entra Agent ID sidecar and the token refresher are security-critical components that each do one job and are easy to audit in isolation. Keeping the agent image free of Entra and AWS credential-fetching code also means you can swap the agent framework (LangChain → Semantic Kernel → anything) without touching either auth path.
@@ -227,7 +227,7 @@ Before provisioning anything, pick a SKU for each of the following. The table li
 > [!WARNING]
 > **Bedrock model ID / region mismatch.** Requesting model access in the Bedrock console returns "Access granted" for the base model ID (`anthropic.claude-3-haiku-…`). The inference-profile form (`us.anthropic.…`) requires the region to be in the profile's region group. Outside `us-east-*` / `us-west-2`, use the regional base model ID.
 
-For the full decision matrix, see the skill reference: [`sku-sizing.md`](../../.github/skills/deploy-agent-aca-aws/references/sku-sizing.md).
+For the full decision matrix, see the skill reference: [`sku-sizing.md`](../../../.claude/skills/deploy-agent-aca-aws/references/sku-sizing.md).
 
 ## 3. Plan your federation topology
 
@@ -707,7 +707,7 @@ PREV_REV=$(az containerapp revision list -g "$RG" -n "$APP_NAME" \
 
 ### 11.1 Add the app's FQDN to the Client SPA redirect URIs
 
-The Client SPA app was created in [§5.2](#52-register-the-client-spa-app) with only `http://localhost:3003` as a redirect URI. The production FQDN must be added manually.
+The Client SPA app was created in [§5.2](#52-register-the-client-spa-app) with only `http://localhost:3003` as a redirect URI. The deployed FQDN must be added manually.
 
 ```bash
 GRAPH_TOKEN=$(az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv)
@@ -825,7 +825,7 @@ If `AssumeRole` (without `WithWebIdentity`) appears, or `AccessDenied` is logged
 |---|---|---|
 | `InvalidIdentityToken: Incorrect token audience` (boto3 → STS) | MI token's audience is a GUID; STS rejects it | See [§14.1](#141-invalididentitytoken-incorrect-token-audience). |
 | `AADSTS65001: consent not granted` on OBO sign-in | Agent SP has app permissions only, not delegated `User.Read` | See [§14.2](#142-aadsts65001-user-or-administrator-has-not-consented). |
-| `AADSTS50011: redirect URI mismatch` in browser | SPA app is missing the production `https://<FQDN>` redirect URI | Add the production redirect URI to the Client SPA (see [§11](#11-phase-7--post-deployment-wiring)). |
+| `AADSTS50011: redirect URI mismatch` in browser | SPA app is missing the deployed `https://<FQDN>` redirect URI | Add the deployed redirect URI to the Client SPA (see [§11](#11-phase-7--post-deployment-wiring)). |
 | Graph `$filter=appId eq` returns empty for the Blueprint | Agent Identity Blueprint types are invisible to `$filter` | Use key-lookup form `/beta/applications(appId='<id>')`. The scripts in this repo already do this. |
 | `Directory.AccessAsUser.All` scope required (pwsh) | `az account get-access-token --resource graph` includes this scope, which Blueprint PATCH rejects | See [§14.3](#143-request_badrequest--directoryaccessasuserall). |
 | `403 Authorization_RequestDenied` on Blueprint create | User has `Application Administrator` but not an Agent ID role | Assign `Agent ID Developer` (template `adb2368d-a9be-41b5-8667-d96778e081b0`) or `Agent ID Administrator`. |
@@ -970,21 +970,70 @@ Source: [`sidecar/aws/azure-token-refresher/refresh.py`](../../../sidecar/aws/az
 
 ## 18. Appendix C — Clean teardown
 
+> **TIP — AI-assisted teardown.** If you use Claude Code or GitHub Copilot, invoke the [`teardown-agent-aca-aws`](../../../.claude/skills/teardown-agent-aca-aws/SKILL.md) skill. It runs the same commands below with dry-run by default and prompts at each destructive step.
+>
+> ```bash
+> # Dry run (default — prints commands, deletes nothing)
+> bash .claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
+>
+> # Azure only
+> DRY_RUN=0 bash .claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
+>
+> # Full teardown (Azure + AWS + Entra)
+> DRY_RUN=0 DELETE_AWS=1 DELETE_ENTRA=1 \
+>   bash .claude/skills/teardown-agent-aca-aws/scripts/teardown-aca-aws.sh
+> ```
+
+### 18.1 Order of operations
+
+Teardown follows the reverse of deployment. Run these in order; each step is safe to re-run if it partially fails.
+
+1. **Revoke OAuth consent** on the Agent SP (keeps a future redeploy clean).
+2. **Delete the Azure resource group** — removes the Container App, ACA environment, ACR, Log Analytics workspace, and the managed identity in one shot.
+3. **Delete AWS objects** *(opt-in)* — IAM role and OIDC provider. Skip if other roles in the same AWS account use the OIDC provider.
+4. **Delete Entra objects** *(opt-in)* — Intermediary app, Client SPA, Agent Identity, Blueprint. Blueprints are often shared across agents — **re-confirm before deleting**.
+
+### 18.2 Manual commands
+
 ```bash
-# Azure
+# 0. Load the deployment variables
+source /tmp/deploy-vars.sh
+
+# 1. Revoke OAuth consent on the Agent SP
+AGENT_SP_OID=$(az ad sp show --id "$AGENT_CLIENT_ID" --query id -o tsv)
+az rest --method GET \
+  --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants?\$filter=clientId eq '$AGENT_SP_OID'" \
+  --query 'value[].id' -o tsv | while read -r g; do
+    az rest --method DELETE --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants/$g"
+  done
+
+# 2. Azure — deletes Container App, ACA env, ACR, Log Analytics, MI in one call
 az group delete --name "$RG" --yes --no-wait
 
-# AWS
+# 3. AWS — only if nothing else uses this OIDC provider
 aws iam delete-role-policy --role-name "$AWS_ROLE_NAME" --policy-name BedrockInvokeOnly
 aws iam delete-role --role-name "$AWS_ROLE_NAME"
 aws iam delete-open-id-connect-provider \
   --open-id-connect-provider-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/sts.windows.net/${TENANT_ID}/"
 
-# Entra
-az ad app delete --id "$STS_APP_ID"
-az ad app delete --id "$CLIENT_SPA_APP_ID"
-# Delete the Blueprint and Agent via the Agent ID portal or Graph — see the Agent ID delete docs.
+# 4. Entra (opt-in — delete in this order)
+az ad app delete --id "$STS_APP_ID"          # Intermediary (AWS-federation-only)
+az ad app delete --id "$CLIENT_SPA_APP_ID"   # Client SPA
+# Agent Identity — via Agent ID portal, or Graph:
+az rest --method DELETE --uri "https://graph.microsoft.com/beta/agentIdentities/$AGENT_CLIENT_ID"
+# Blueprint — re-confirm, this may be shared:
+az ad app delete --id "$BLUEPRINT_APP_ID"
 ```
+
+### 18.3 Verify
+
+```bash
+az group exists --name "$RG"                                          # expect: false
+aws iam get-role --role-name "$AWS_ROLE_NAME" 2>&1 | head -1          # expect: NoSuchEntity
+az ad app show --id "$STS_APP_ID" 2>&1 | head -1                      # expect: not found
+```
+
+FICs on the Blueprint and Intermediary apps that point at the now-deleted MI become orphaned but inert — they cannot be re-used. Clean them with `az ad app federated-credential list/delete` if cosmetic cleanup matters.
 
 ## 19. References
 

--- a/deploy/azure/container-apps/dev/README.md
+++ b/deploy/azure/container-apps/dev/README.md
@@ -21,9 +21,9 @@ In this tutorial, you learn how to:
 > * Verify the autonomous and on-behalf-of (OBO) identity flows end to end.
 
 > [!TIP]
-> **Recommended approach: AI-assisted setup.** This tutorial has several moving parts — Entra role assignments, the Ollama model-pull strategy (runtime vs baked), ACR image builds, and post-deploy manual wiring. Running it end-to-end by hand is fully supported (every command is documented below), but the fastest and least error-prone path is to **pair an AI assistant with the skill packaged in this repo**: [`.claude/skills/deploy-agent-aca-dev/SKILL.md`](../../../.claude/skills/deploy-agent-aca-dev/SKILL.md).
+> **Recommended: AI-assisted deployment.** The fastest, least error-prone way to finish this tutorial is to pair an AI assistant with the skill packaged in this repo: [`.claude/skills/deploy-agent-aca-dev/SKILL.md`](../../../.claude/skills/deploy-agent-aca-dev/SKILL.md). The assistant confirms your SKU choices, picks the right Ollama model strategy, handles the post-deploy manual steps, and surfaces known failure modes in real time — typically cutting deployment time from hours to minutes. Running the tutorial end-to-end by hand is fully supported (every command is documented below); the skill just front-loads the decisions.
 >
-> The skill works with **Claude Code** (which reads `.claude/skills/` by default) and with **GitHub Copilot Chat** (ask it to read the `SKILL.md` file). The assistant confirms your SKU choices, picks the right Ollama model strategy, handles the post-deploy manual steps, and surfaces known failure modes in real time. If you prefer a manual run, continue reading — the tutorial remains the source of truth.
+> The skill works with **Claude Code** (which reads `.claude/skills/` by default) and with **GitHub Copilot Chat** (ask it to read the `SKILL.md` file). If you prefer a manual run, continue reading — the tutorial remains the source of truth.
 
 ## 1. Overview
 
@@ -177,7 +177,7 @@ Before provisioning anything, pick a SKU for each of the following. The table li
 > [!WARNING]
 > **`OLLAMA_IMAGE_STRATEGY=runtime-pull` on scale-to-zero.** Compounds: the first request after idle triggers an image pull AND a model download. User waits 30–60 s for the first answer. Don't combine.
 
-For the full decision matrix, see the skill reference: [`sku-sizing.md`](../../.github/skills/deploy-agent-aca-dev/references/sku-sizing.md).
+For the full decision matrix, see the skill reference: [`sku-sizing.md`](../../../.claude/skills/deploy-agent-aca-dev/references/sku-sizing.md).
 
 ## 3. Final object inventory
 
@@ -273,7 +273,7 @@ export CLIENT_SPA_APP_ID=$(grep '^CLIENT_SPA_APP_ID=' scripts/.env | cut -d= -f2
 ### 5.3 Configure the Blueprint for OBO
 
 ```powershell
-pwsh -NoProfile -File .github/skills/deploy-agent-aca-dev/scripts/setup-obo-blueprint-for-aca.ps1 `
+pwsh -NoProfile -File .claude/skills/deploy-agent-aca-dev/scripts/setup-obo-blueprint-for-aca.ps1 `
   -BlueprintAppId $env:BLUEPRINT_APP_ID `
   -ClientSpaAppId $env:CLIENT_SPA_APP_ID `
   -AgentAppId $env:AGENT_CLIENT_ID `
@@ -285,7 +285,7 @@ pwsh -NoProfile -File .github/skills/deploy-agent-aca-dev/scripts/setup-obo-blue
 OBO requires a **delegated** `User.Read` grant in addition to the application permissions `Start-EntraAgentIDWorkflow` already granted. Without this, users hit `AADSTS65001`.
 
 ```powershell
-pwsh -NoProfile -File .github/skills/deploy-agent-aca-dev/scripts/grant-agent-obo-consent.ps1 `
+pwsh -NoProfile -File .claude/skills/deploy-agent-aca-dev/scripts/grant-agent-obo-consent.ps1 `
   -AgentAppId $env:AGENT_CLIENT_ID -TenantId $env:TENANT_ID
 ```
 
@@ -513,7 +513,7 @@ Same two manual steps as the AWS variant — both are tenant-level Entra/Graph o
 ### 10.1 Add the app's FQDN to the Client SPA redirect URIs
 
 ```bash
-bash .github/skills/deploy-agent-aca-dev/scripts/add-spa-redirect-uri.sh
+bash .claude/skills/deploy-agent-aca-dev/scripts/add-spa-redirect-uri.sh
 ```
 
 This PATCHes `spa.redirectUris` on the Client SPA app directly via Graph. `az ad app update --web-redirect-uris` does **not** affect SPA redirect URIs.
@@ -584,7 +584,7 @@ There is no AWS or GCP rotation — because there is no AWS or GCP.
 | Ollama logs show `pulling manifest…` then 404 | Model name / tag wrong | Verify the exact name with `docker run --rm ollama/ollama:latest ollama pull <name>` locally |
 | First request hangs 30+ s | `runtime-pull` strategy cold start | Switch to the `baked` strategy |
 | `AADSTS65001` on browser OBO sign-in | Missing delegated `User.Read` admin consent | Run `grant-agent-obo-consent.ps1` (see [§5.4](#54-admin-consent-the-agents-delegated-graph-permission)) |
-| `AADSTS50011: redirect URI mismatch` | Production `https://<FQDN>` not in SPA redirect URIs | Run `add-spa-redirect-uri.sh` (see [§10.1](#101-add-the-apps-fqdn-to-the-client-spa-redirect-uris)) |
+| `AADSTS50011: redirect URI mismatch` | Deployed `https://<FQDN>` not in SPA redirect URIs | Run `add-spa-redirect-uri.sh` (see [§10.1](#101-add-the-apps-fqdn-to-the-client-spa-redirect-uris)) |
 | `AADSTS50079` on `az login` | New user has not completed MFA enrollment | Sign in once via browser to enroll, then retry |
 | Graph `$filter=appId eq` returns empty for Blueprint | Agent Identity Blueprint types invisible to `$filter` | Use key-lookup form `/beta/applications(appId='<id>')` — the scripts in this skill already do this |
 | <a name="133-request_badrequest-directoryaccessasuserall"></a>`REQUEST_BADREQUEST: Directory.AccessAsUser.All` on Blueprint PATCH | `az account get-access-token --resource graph` includes `Directory.AccessAsUser.All` which Blueprint rejects | Use pwsh `Connect-MgGraph -Scopes …` with narrow scopes (never `.default`) |
@@ -624,6 +624,60 @@ az containerapp logs show -g "$RG" -n "$APP_NAME" --container sidecar --tail 50
 | Per-token model cost | **$0** (Ollama local) |
 
 Switching to Dedicated-D4 for latency adds ~$140/mo and removes cold-start latency. Moving to a GPU profile for larger models adds ~$2k+/mo.
+
+## 15. Clean teardown
+
+> **TIP — AI-assisted teardown.** If you use Claude Code or GitHub Copilot, invoke the [`teardown-agent-aca-dev`](../../../.claude/skills/teardown-agent-aca-dev/SKILL.md) skill. It runs the same commands below with dry-run by default and prompts at each destructive step.
+>
+> ```bash
+> # Dry run (default — prints commands, deletes nothing)
+> bash .claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
+>
+> # Azure only
+> DRY_RUN=0 bash .claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
+>
+> # Full teardown (Azure + Entra apps)
+> DRY_RUN=0 DELETE_ENTRA=1 \
+>   bash .claude/skills/teardown-agent-aca-dev/scripts/teardown-aca-dev.sh
+> ```
+
+### 15.1 Order of operations
+
+1. **Revoke OAuth consent** on the Agent SP so a future redeploy starts from a clean state.
+2. **Delete the Azure resource group** — removes the Container App, ACA environment, ACR (with the baked Ollama image), Log Analytics workspace, and managed identity in one call.
+3. **Delete Entra objects** *(opt-in)* — Client SPA, Agent Identity, Blueprint. Blueprints are often shared — **re-confirm before deleting**.
+
+### 15.2 Manual commands
+
+```bash
+# 0. Load the deployment variables
+source /tmp/deploy-vars.sh
+
+# 1. Revoke OAuth consent on the Agent SP
+AGENT_SP_OID=$(az ad sp show --id "$AGENT_CLIENT_ID" --query id -o tsv)
+az rest --method GET \
+  --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants?\$filter=clientId eq '$AGENT_SP_OID'" \
+  --query 'value[].id' -o tsv | while read -r g; do
+    az rest --method DELETE --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants/$g"
+  done
+
+# 2. Azure — deletes Container App, ACA env, ACR, Log Analytics, MI in one call
+az group delete --name "$RG" --yes --no-wait
+
+# 3. Entra (opt-in)
+az ad app delete --id "$CLIENT_SPA_APP_ID"
+# Agent Identity — via Agent ID portal, or Graph:
+az rest --method DELETE --uri "https://graph.microsoft.com/beta/agentIdentities/$AGENT_CLIENT_ID"
+# Blueprint — re-confirm, this may be shared:
+az ad app delete --id "$BLUEPRINT_APP_ID"
+```
+
+### 15.3 Verify
+
+```bash
+az group exists --name "$RG"                              # expect: false
+az ad app show --id "$CLIENT_SPA_APP_ID" 2>&1 | head -1   # expect: not found (if Entra deleted)
+```
 
 ## Appendix A — Secretless migration from docker-compose
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -9,6 +9,9 @@ For runnable samples, see:
 
 For the PowerShell bootstrap that creates the Entra objects used by every sample, see [`../scripts/README.md`](../scripts/README.md).
 
+> [!TIP]
+> **Deploying these samples to Azure?** Use the AI-assisted skills for a faster, less error-prone path than running every command by hand: [`deploy-agent-aca-dev`](../.claude/skills/deploy-agent-aca-dev/SKILL.md) (local-LLM on ACA) and [`deploy-agent-aca-aws`](../.claude/skills/deploy-agent-aca-aws/SKILL.md) (AWS Bedrock on ACA). Each skill works with Claude Code and GitHub Copilot Chat and typically cuts a multi-hour manual deploy down to minutes.
+
 ## The problem
 
 Two common approaches to agent authentication both fall short:
@@ -26,7 +29,7 @@ The **[Microsoft Entra SDK auth sidecar](https://mcr.microsoft.com/en-us/product
 - Client-credentials or federated identity credential (FIC) token acquisition for the Agent Identity (autonomous flow)
 - On-Behalf-Of (OBO) flows for user-context calls
 - Token caching, refresh, and expiry
-- Credential source abstraction — `ClientSecret` for dev, `SignedAssertionFromManagedIdentity` for production, same API
+- Credential source abstraction — `ClientSecret` for dev, `SignedAssertionFromManagedIdentity` for Azure deployments, same API
 
 Your agent asks the sidecar *"give me an authorization header for this API"* and gets back `Bearer eyJ…`. Credentials never live in agent memory.
 
@@ -57,7 +60,7 @@ Provisioning is covered in [`../scripts/README.md`](../scripts/README.md) — th
 - How the sidecar exposes `/AuthorizationHeader` (get token) and `/DownstreamApi` (token + proxied call) endpoints.
 - How to forward a signed-in user's token to the agent and have the Microsoft Entra SDK for Agent ID mint an agent-on-behalf-of-user token via OBO.
 - How the downstream API validates agent tokens cryptographically — signature, issuer, `xms_par_app_azp`, audience.
-- How to swap from `ClientSecret` (dev) to `SignedAssertionFromManagedIdentity` (Azure production) without changing a line of agent code.
+- How to swap from `ClientSecret` (dev) to `SignedAssertionFromManagedIdentity` (Azure deployments) without changing a line of agent code.
 
 ## Next steps
 

--- a/sidecar/aws/README.md
+++ b/sidecar/aws/README.md
@@ -14,7 +14,7 @@ This sample deliberately uses the **official [Microsoft Entra SDK auth sidecar](
 
 - **Interoperable across any cloud or on-prem** — the same container image runs identically on Azure, AWS, GCP, Kubernetes, or a laptop. This sample puts it next to **AWS Bedrock** to make the cross-cloud story concrete: the LLM is in AWS, identity is in Microsoft Entra, and neither side cares.
 - **Your agent code stays decoupled from token exchanges.** The agent never handles `client_id`, `client_secret`, certificates, JWKS, token caching, or OBO exchange. It just asks the sidecar: *"Give me an authorization header for this downstream API."*
-- **Swap credentials without touching agent code.** `ClientSecret` for dev, `SignedAssertionFromManagedIdentity` for production on Azure — change one env var, no code changes.
+- **Swap credentials without touching agent code.** `ClientSecret` for dev, `SignedAssertionFromManagedIdentity` when deployed on Azure — change one env var, no code changes.
 - **Token caching, refresh, and expiry are handled for you.** No MSAL integration to debug.
 - **Security boundary is explicit.** The sidecar has no host port. Only services inside the Docker network can request tokens — your agent, not your browser, not random processes on the host.
 
@@ -36,7 +36,7 @@ This sample deliberately uses the **official [Microsoft Entra SDK auth sidecar](
 - **Full token lifecycle**: Tc (user token) → T1 (blueprint app token) → TR (agent token) → downstream API
 - **JWT validation end-to-end**: The weather API verifies signature (JWKS / RS256), issuer, and expiry on every request
 - **LangGraph ReAct agent**: Modern LangChain 1.x pattern with `langchain.agents.create_agent`
-- **Three production-ready AWS auth tiers** documented: temporary STS creds, Bedrock API keys, and OIDC federation (no secrets) — see [§5](#5-aws-authentication--pick-the-right-tier)
+- **Three deployment-ready AWS auth tiers** documented: temporary STS creds, Bedrock API keys, and OIDC federation (no secrets) — see [§5](#5-aws-authentication--pick-the-right-tier)
 
 ### Modes and flows (2×2 matrix)
 
@@ -172,9 +172,9 @@ The sample supports three ways to authenticate to Bedrock. Pick based on where y
 |---|---|---|---|---|
 | **A. Temporary STS creds** | Local dev, your laptop, your AWS SSO | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_SESSION_TOKEN` in `.env` | ~1 hour | Yes (in gitignored `.env`) |
 | **B. Bedrock API key** | Public demos, workshops, hands-on labs | `AWS_BEARER_TOKEN_BEDROCK` in `.env` | Long- or short-term, scoped to Bedrock only | Yes (in gitignored `.env`) |
-| **C. OIDC federation** | **Production on Azure App Service** | Platform App Settings (no `.env`); `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE` | Auto-rotated by AWS STS | **No** — zero stored secrets |
+| **C. OIDC federation** | **Deployed on Azure App Service** | Platform App Settings (no `.env`); `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE` | Auto-rotated by AWS STS | **No** — zero stored secrets |
 
-> **Production deployment instructions:** see **[`DEPLOY-AZURE-APP-SERVICE.md`](./DEPLOY-AZURE-APP-SERVICE.md)** for the full step-by-step guide using tier (C) — Azure Managed Identity → AWS IAM role via OIDC federation, with no AWS keys ever stored anywhere.
+> **For hosted deployments:** see **[`DEPLOY-AZURE-APP-SERVICE.md`](./DEPLOY-AZURE-APP-SERVICE.md)** for the full step-by-step guide using tier (C) — Azure Managed Identity → AWS IAM role via OIDC federation, with no AWS keys ever stored anywhere.
 
 `.env.example` documents all three tiers with side-by-side examples.
 
@@ -345,7 +345,7 @@ The sidecar supports multiple credential types via `AzureAd__ClientCredentials__
 | SourceType | When to use |
 |---|---|
 | `ClientSecret` | **Local dev only** — what this sample ships with |
-| `SignedAssertionFromManagedIdentity` | **Production on Azure** — zero secrets, recommended (see [`DEPLOY-AZURE-APP-SERVICE.md`](./DEPLOY-AZURE-APP-SERVICE.md)) |
+| `SignedAssertionFromManagedIdentity` | **Deployed on Azure** — zero secrets, recommended (see [`DEPLOY-AZURE-APP-SERVICE.md`](./DEPLOY-AZURE-APP-SERVICE.md)) |
 | `KeyVault` | Certificate from Azure Key Vault |
 | `StoreWithThumbprint` | Certificate from local machine store |
 
@@ -419,11 +419,14 @@ Override via `BEDROCK_MODEL_ID` in `.env`. You must enable each model in the **A
 
 ---
 
-## 12. Production deployment
+## 12. Deploying on Azure
 
-The dev workflow above puts secrets in `.env`. **Do not deploy that to production.** For Azure App Service, follow the dedicated guide:
+The dev workflow above puts secrets in `.env`. **Don't ship that to a hosted environment.** For Azure App Service, follow the dedicated guide:
 
 **→ [`DEPLOY-AZURE-APP-SERVICE.md`](./DEPLOY-AZURE-APP-SERVICE.md)**
+
+> [!TIP]
+> **For Azure Container Apps**, there's an AI-assisted tutorial + skill at [`deploy/azure/container-apps/aws/README.md`](../../deploy/azure/container-apps/aws/README.md) that handles the v1 token exchange, intermediary app, and post-deploy wiring for you. It typically cuts a multi-hour manual deploy down to minutes.
 
 It walks through, step by step:
 
@@ -482,7 +485,7 @@ sidecar/aws/
 ├── Dockerfile                        # Python 3.11 slim base
 ├── requirements.txt                  # LangChain 1.x, langchain-aws, Flask, MSAL
 ├── .env.example                      # Template — copy to .env (3 AWS auth tiers documented)
-├── DEPLOY-AZURE-APP-SERVICE.md       # Production deployment with OIDC federation
+├── DEPLOY-AZURE-APP-SERVICE.md       # Azure App Service deployment with OIDC federation
 ├── templates/
 │   └── index.html                    # Chat UI, MSAL.js, identity trace panel
 └── tests/

--- a/sidecar/dev/README.md
+++ b/sidecar/dev/README.md
@@ -12,7 +12,7 @@ This sample deliberately uses the **official [Microsoft Entra SDK auth sidecar](
 
 - **Interoperable across any cloud or on-prem** — the same container image (`mcr.microsoft.com/entra-sdk/auth-sidecar`) runs identically on Azure, AWS, GCP, Kubernetes, or a laptop. Standard OAuth2 flows (client credentials, OBO, federated credentials) are implemented once by the identity team and consumed the same way everywhere.
 - **Your agent code stays decoupled from token exchanges.** The LLM agent never handles `client_id`, `client_secret`, certificates, JWKS, token caching, or OBO exchange. It just asks the sidecar: *"Give me an authorization header for this downstream API."*
-- **Swap credentials without touching agent code.** `ClientSecret` for dev, `SignedAssertionFromManagedIdentity` for production on Azure — change one env var, no code changes.
+- **Swap credentials without touching agent code.** `ClientSecret` for dev, `SignedAssertionFromManagedIdentity` when deployed on Azure — change one env var, no code changes.
 - **Token caching, refresh, and expiry are handled for you.** No MSAL integration to debug.
 - **Security boundary is explicit.** The sidecar has no host port. Only services inside the Docker network can request tokens — your agent, not your browser, not random processes on the host.
 
@@ -25,7 +25,10 @@ This sample deliberately uses the **official [Microsoft Entra SDK auth sidecar](
 | Pass through user token for OBO | Validate & forward user assertion |
 | Handle business logic | Talk to `login.microsoftonline.com` |
 
-If you're shipping an agent to production, **this separation is the recommended pattern** — your code never sees a secret, and all credential policy lives in one place.
+When you deploy this agent beyond your laptop, **this separation is the recommended pattern** — your code never sees a secret, and all credential policy lives in one place.
+
+> [!TIP]
+> **Deploying to Azure Container Apps?** Use the AI-assisted tutorial + skill at [`deploy/azure/container-apps/dev/README.md`](../../deploy/azure/container-apps/dev/README.md). It handles the switch from `ClientSecret` to `SignedAssertionFromManagedIdentity`, federated-credential wiring, and post-deploy manual steps — typically cutting a multi-hour manual deploy down to minutes.
 
 ---
 
@@ -304,7 +307,7 @@ The sidecar supports multiple credential types via `AzureAd__ClientCredentials__
 | SourceType | When to use |
 |---|---|
 | `ClientSecret` | **Local dev only** — what this sample ships with |
-| `SignedAssertionFromManagedIdentity` | **Production on Azure** — zero secrets, recommended |
+| `SignedAssertionFromManagedIdentity` | **Deployed on Azure** — zero secrets, recommended |
 | `KeyVault` | Certificate from Azure Key Vault |
 | `StoreWithThumbprint` | Certificate from local machine store |
 


### PR DESCRIPTION
## Summary

Three coordinated doc-polish changes:

### 1. Teardown skills for both ACA deployments
- New `.claude/skills/teardown-agent-aca-aws/` and `.claude/skills/teardown-agent-aca-dev/` (SKILL.md + orchestrator script).
- Safety posture: dry-run by default; Entra and AWS cleanup are opt-in via `DELETE_ENTRA=1` / `DELETE_AWS=1`; Blueprint deletion re-prompts because Blueprints are often shared.
- Rewrite Appendix C in AWS tutorial and add new §15 Cleanup section in dev tutorial: order of operations, manual commands, verify steps, AI-assisted TIP.

### 2. Context-aware 'production' replacements
The word was doing different work in different places. Replaced per context:

| Context | Replacement |
|---|---|
| 'production downstream service' | 'hardened downstream service' |
| 'production FQDN / redirect URI' (ACA ingress) | 'deployed FQDN / redirect URI' |
| '`SignedAssertionFromManagedIdentity` for production on Azure' | 'when deployed on Azure' / 'for Azure deployments' |
| 'If you're shipping an agent to production' | 'When you deploy this agent beyond your laptop' |
| sidecar/aws §12 heading 'Production deployment' | 'Deploying on Azure' |
| 'Do not deploy that to production' | 'Don't ship that to a hosted environment' |
| 'production-ready AWS auth tiers' | 'deployment-ready AWS auth tiers' |
| SKU sizing 'iteration, debugging, or production use' | 'iteration, debugging, or real workloads' |
| permissions.md 'Recommended for production setup' | 'Recommended for shared-tenant setup' |
| teardown SKILL 'Production —' | 'Hardened / long-lived deployments —' |

`ASPNETCORE_ENVIRONMENT: "Production"` is left untouched — that's a .NET runtime value, not prose.

### 3. Highlight AI-assisted deployment across the docs
- Added TIP callouts to root README, `sidecar/README.md`, `sidecar/dev/README.md`, and `sidecar/aws/README.md §12` pointing at the matching `.claude/skills/deploy-agent-aca-*` skills.
- Reworded the existing tutorial TIPs to quantify the delta ('typically cutting a multi-hour manual deploy down to minutes').
- Fixed stale `.github/skills/` → `.claude/skills/` paths left over from PR #10 (both ACA tutorials + the two deploy skills' internals).

## Testing
- Dry-run both teardown orchestrators against fake vars → clean output, no destructive side effects.
- `bash -n` syntax-checks both scripts.
- `grep -r 'production'` across docs returns only the two legitimate `ASPNETCORE_ENVIRONMENT` values.
- `grep -r '.github/skills/'` across docs returns nothing.

## Stats
17 files changed, +716/-57.