### PR TITLE
docs(aws): add Bedrock invoke-model pre-flight check before deploy

### DIFF
--- a/.claude/skills/deploy-agent-aca-aws/SKILL.md
+++ b/.claude/skills/deploy-agent-aca-aws/SKILL.md
@@ -27,9 +27,20 @@ End-to-end, secretless deployment of the AWS sample agent (`sidecar/aws`) to Azu
 
 1. **Entra role** on signing-in user — one of: `Global Administrator`, `Agent ID Administrator`, `Agent ID Developer`. `Application Administrator` alone returns 403 on blueprint creation. See [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md).
 2. **AWS Bedrock access** enabled for `anthropic.claude-3-haiku-20240307-v1:0` in the target region (request via Bedrock console if needed).
-3. **Tooling**: `az` ≥ 2.60, `aws` v2, `pwsh` 7.4+, `Microsoft.Graph.*` 2.35+, `docker buildx` for `linux/amd64`.
-4. **Tenant-confirmed preflight** — ALWAYS confirm tenant ID + subscription ID with the user before any `az` command that mutates resources (user has multiple accounts; see user memory).
-5. **Entra Agent ID base objects** exist — Blueprint, Agent Identity, Client SPA. If not, run the [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md) skill first.
+3. **Bedrock pre-flight** — run a real `invoke-model` call **before** provisioning anything. Confirms access + region + credentials in 30 seconds. Most late-stage failures in this skill come from skipping this.
+
+   ```bash
+   aws bedrock-runtime invoke-model \
+     --region "$AWS_REGION" --model-id "$BEDROCK_MODEL_ID" \
+     --body '{"anthropic_version":"bedrock-2023-05-31","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}' \
+     --cli-binary-format raw-in-base64-out /tmp/bedrock-preflight.json \
+     && echo "✅ ok" || echo "❌ fix access/region before deploying"
+   ```
+
+   If it fails, stop and fix before continuing. Common causes: model access not granted (console → Model access), wrong region for the inference profile (`us.` IDs require `us-east-1` / `us-east-2` / `us-west-2`), expired AWS creds. Full error table: [deploy/azure/container-apps/aws/README.md §2.2.1](../../../deploy/azure/container-apps/aws/README.md#221-pre-flight-verify-bedrock-access-before-deploying).
+4. **Tooling**: `az` ≥ 2.60, `aws` v2, `pwsh` 7.4+, `Microsoft.Graph.*` 2.35+, `docker buildx` for `linux/amd64`.
+5. **Tenant-confirmed preflight** — ALWAYS confirm tenant ID + subscription ID with the user before any `az` command that mutates resources (user has multiple accounts; see user memory).
+6. **Entra Agent ID base objects** exist — Blueprint, Agent Identity, Client SPA. If not, run the [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md) skill first.
 
 ## SKU decisions — ask the user first
 

--- a/deploy/azure/container-apps/aws/README.md
+++ b/deploy/azure/container-apps/aws/README.md
@@ -183,6 +183,36 @@ Static credentials survive leaks (often for months). Federated tokens in this de
 * An AWS account with Bedrock model access enabled in your target region for **Anthropic Claude 3 Haiku**. Request access from the Bedrock console if needed.
 * An IAM principal with permission to create OIDC identity providers and IAM roles.
 
+#### 2.2.1 Pre-flight: verify Bedrock access before deploying
+
+Run this 30-second check **before** provisioning anything. It confirms three things at once: model access is granted, the region hosts the model, and your AWS credentials work. Most late-stage deploy failures in this tutorial come from skipping this step.
+
+```bash
+AWS_REGION=us-east-2
+BEDROCK_MODEL_ID=us.anthropic.claude-3-haiku-20240307-v1:0
+
+aws bedrock-runtime invoke-model \
+  --region "$AWS_REGION" \
+  --model-id "$BEDROCK_MODEL_ID" \
+  --body '{"anthropic_version":"bedrock-2023-05-31","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/bedrock-preflight.json \
+  && echo "✅ Bedrock reachable from this account/region" \
+  || echo "❌ Fix access/region before deploying"
+```
+
+**If you see an error, these are the common ones:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `AccessDeniedException: You don't have access to the model with the specified model ID` | Model access not granted in this account | Bedrock console → **Model access** → enable **Anthropic Claude 3 Haiku**. Approval is usually instant. |
+| `ValidationException: Invocation of model ID … isn't supported in …` | Region doesn't host the inference profile | Use `us-east-1`, `us-east-2`, or `us-west-2` for `us.anthropic.…` IDs; or switch to the bare `anthropic.claude-3-haiku-…` ID for other regions. |
+| `ExpiredTokenException` / `InvalidClientTokenId` | AWS creds missing or expired | `aws sso login` or export fresh STS creds. |
+| `AccessDeniedException: bedrock:InvokeModel` | IAM principal is missing the action | Attach `bedrock:InvokeModel` on `arn:aws:bedrock:*::foundation-model/anthropic.claude-3-haiku-*` and on the inference-profile ARN. |
+
+> [!TIP]
+> If you only want to check whether the model exists in the region (without invoking it), use `aws bedrock list-foundation-models --region "$AWS_REGION" --query 'modelSummaries[?contains(modelId,\`claude-3-haiku\`)].modelId'`. This doesn't tell you whether access is granted — only `invoke-model` does that end-to-end.
+
 ### 2.3 Tooling
 
 | Tool | Minimum version | Notes |


### PR DESCRIPTION
## Summary

Adds a 30-second Bedrock pre-flight check to both:
- **AWS ACA tutorial** `deploy/azure/container-apps/aws/README.md` — new §2.2.1 right after AWS prerequisites
- **AWS deploy skill** `.claude/skills/deploy-agent-aca-aws/SKILL.md` — prerequisites step 3

The check is a single `aws bedrock-runtime invoke-model` call that confirms three things at once: model access is granted, the region actually hosts the model, and AWS credentials work. Most late-stage failures in the AWS deploy flow trace back to skipping this.

## Common-error table included

| Error | Cause | Fix |
|---|---|---|
| `AccessDeniedException: You don't have access to the model` | Access not granted | Bedrock console → Model access → enable Claude 3 Haiku |
| `ValidationException: Invocation of model ID … isn't supported` | Wrong region for inference profile | Use `us-east-1` / `us-east-2` / `us-west-2` for `us.` IDs |
| `ExpiredTokenException` / `InvalidClientTokenId` | Creds expired | `aws sso login` |
| `AccessDeniedException: bedrock:InvokeModel` | IAM action missing | Attach on model ARN + inference-profile ARN |

## Stats
2 files changed, +44/-3.