### PR TITLE
docs: surface AWS local demo + fix stale Entra-bootstrap pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Runnable samples for **Microsoft Entra Agent ID** — Entra's purpose-built iden
 ## Quick start
 
 1. Provision Entra objects: [`scripts/README.md`](scripts/README.md)
-2. Run a local demo: [`sidecar/dev/README.md`](sidecar/dev/README.md)
+2. Run a local demo:
+   - Local-LLM (Ollama, offline): [`sidecar/dev/README.md`](sidecar/dev/README.md)
+   - AWS Bedrock (Claude): [`sidecar/aws/README.md`](sidecar/aws/README.md)
 3. Deploy to Azure Container Apps: [`deploy/azure/container-apps/dev/README.md`](deploy/azure/container-apps/dev/README.md) (local-LLM) or [`deploy/azure/container-apps/aws/README.md`](deploy/azure/container-apps/aws/README.md) (AWS Bedrock)
 
 > [!TIP]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,7 +75,7 @@ BLUEPRINT_CLIENT_SECRET=<secret from Start-EntraAgentIDWorkflow>
 AGENT_CLIENT_ID=<agent-app-id from Step 1>
 ```
 
-> For production on Azure App Service / Container Apps, **do not set `BLUEPRINT_CLIENT_SECRET`**. Use `SourceType=SignedAssertionFromManagedIdentity` instead. See [`../deploy/azure/container-apps/`](../deploy/azure/container-apps/).
+> When deployed on Azure App Service / Container Apps, **do not set `BLUEPRINT_CLIENT_SECRET`**. Use `SourceType=SignedAssertionFromManagedIdentity` instead. See [`../deploy/azure/container-apps/`](../deploy/azure/container-apps/).
 
 ### Step 3 — Start the sidecar
 

--- a/sidecar/aws/README.md
+++ b/sidecar/aws/README.md
@@ -158,7 +158,7 @@ Works on **macOS**, **Linux**, and **Windows 10/11**.
 
 You also need:
 
-1. **A registered Agent ID in Microsoft Entra** — the repo-root PowerShell workflow creates the Blueprint app, client secret, and Agent ID. See [§6.2](#62-first-time-setup--create-the-entra-objects).
+1. **A registered Agent ID in Microsoft Entra** — the PowerShell workflow in [`scripts/README.md`](../../scripts/README.md) creates the Blueprint app, client secret, and Agent ID. See [§6.2](#62-first-time-setup--create-the-entra-objects).
 2. **An AWS account with Bedrock model access** — by default this sample uses `us.anthropic.claude-3-haiku-20240307-v1:0`. Enable model access in the AWS Bedrock console (*Model access → Manage model access → Anthropic Claude 3 Haiku → Save*). Approval is usually instant.
 3. **AWS credentials** for one of the three tiers in [§5](#5-aws-authentication--pick-the-right-tier).
 
@@ -210,9 +210,12 @@ if ((Test-Path .env) -and (Select-String '^BLUEPRINT_APP_ID=.+' .env -Quiet)) { 
 
 Run this **once per tenant**. It creates the Blueprint app, Agent ID, and the SPA app used for OBO sign-in.
 
+> [!TIP]
+> **Using Claude Code or GitHub Copilot Chat?** Invoke the [`entra-agent-id-setup`](../../.claude/skills/entra-agent-id-setup/SKILL.md) skill — it runs steps 6.2a–6.2c in one guided pass and checks your Entra role (`Agent ID Developer` or higher) before creating anything. Typically cuts this section from ~20 minutes to a few.
+
 **a. Create Blueprint + Agent ID** (autonomous flow only)
 
-Follow the PowerShell workflow in the **[repo root README](../../README.md)** (works on macOS, Linux and Windows with [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell)). At the end you'll have:
+Follow the PowerShell workflow in [`scripts/README.md`](../../scripts/README.md) (works on macOS, Linux and Windows with [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell)). At the end you'll have:
 
 - `TENANT_ID` — your Entra tenant
 - `BLUEPRINT_APP_ID` — Blueprint app registration


### PR DESCRIPTION
## Summary

Polishes the first-run experience for users who clone the repo and want to run the AWS Bedrock sample locally.

### Before
1. Root README Quick start only lists 'sidecar/dev/README.md' as the local demo. Users wanting AWS have to discover 'sidecar/aws/' on their own.
2. 'sidecar/aws/README.md' §4 and §6.2a point to 'the repo-root PowerShell workflow' / 'the repo root README' for Entra setup. The root README no longer hosts that workflow (it lives in 'scripts/README.md' now), so the pointer is dead-end.
3. No AI-assisted path called out for Entra bootstrap \u2014 users run every PowerShell command by hand.
4. 'scripts/README.md' still has one 'production on Azure' (missed in PR #14).

### After
1. Root README lists both local demos (dev and aws) explicitly.
2. Both pointers in 'sidecar/aws/README.md' now link directly to 'scripts/README.md'.
3. Added TIP in 'sidecar/aws/README.md' §6.2 recommending the 'entra-agent-id-setup' skill for Claude Code / Copilot users.
4. 'production on Azure' \u2192 'deployed on Azure' (consistent with PR #14 terminology).

## Stats
3 files changed, +9/-4.