### PR TITLE
fix: 13 skill fixes from deployment field testing feedback

### DIFF
--- a/.claude/skills/deploy-agent-aca-aws/SKILL.md
+++ b/.claude/skills/deploy-agent-aca-aws/SKILL.md
@@ -38,7 +38,7 @@ End-to-end, secretless deployment of the AWS sample agent (`sidecar/aws`) to Azu
    ```
 
    If it fails, stop and fix before continuing. Common causes: model access not granted (console → Model access), wrong region for the inference profile (`us.` IDs require `us-east-1` / `us-east-2` / `us-west-2`), expired AWS creds. Full error table: [deploy/azure/container-apps/aws/README.md §2.2.1](../../../deploy/azure/container-apps/aws/README.md#221-pre-flight-verify-bedrock-access-before-deploying).
-4. **Tooling**: `az` ≥ 2.60, `aws` v2, `pwsh` 7.4+, `Microsoft.Graph.*` 2.35+, `docker buildx` for `linux/amd64`.
+4. **Tooling**: `az` ≥ 2.60, `aws` v2, `pwsh` 7.4+, `Microsoft.Graph.*` 2.35+, and one of: `docker buildx` for `linux/amd64` **OR** `az acr build` (no local Docker needed).
 5. **Tenant-confirmed preflight** — ALWAYS confirm tenant ID + subscription ID with the user before any `az` command that mutates resources (user has multiple accounts; see user memory).
 6. **Entra Agent ID base objects** exist — Blueprint, Agent Identity, Client SPA. If not, run the [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md) skill first.
 

--- a/.claude/skills/deploy-agent-aca-aws/references/troubleshooting.md
+++ b/.claude/skills/deploy-agent-aca-aws/references/troubleshooting.md
@@ -34,3 +34,13 @@ az rest --method GET --url "https://graph.microsoft.com/v1.0/applications(appId=
 # Verify Blueprint federated credential subject
 az rest --method GET --url "https://graph.microsoft.com/beta/applications(appId='$BLUEPRINT_APP_ID')/federatedIdentityCredentials"
 ```
+
+## Additional issues (from field testing)
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| `Connect-MgGraph` times out or `User canceled authentication` from `pwsh -Command` subshell | WAM popup hidden behind windows in subshell | Run `Connect-MgGraph` in an interactive `pwsh` session |
+| `WARNING: Missing required scopes` from `EntraAgentID-Functions.ps1` | Skill’s scope list missing `AgentIdentityBlueprint.DeleteRestore.All` and `AgentIdentity.DeleteRestore.All` | Reconnect with all 10 scopes — see `entra-agent-id-setup/SKILL.md` |
+| `Property spa in payload has a value that does not match schema` on PowerShell | JSON escaping in `az ad app update --set spa='{...}'` | Use `az rest --method PATCH` with PowerShell-native JSON serialization |
+| Dedicated-D4 workload profile takes 20+ minutes | Normal Azure provisioning time | Wait. Do not cancel. |
+| `az group create` denied by Azure Policy tag requirements | Org policy requires tags on RGs | Add required tags during `az group create` or use pre-existing RG |

--- a/.claude/skills/deploy-agent-aca-dev/SKILL.md
+++ b/.claude/skills/deploy-agent-aca-dev/SKILL.md
@@ -27,9 +27,17 @@ End-to-end, secretless deployment of `sidecar/dev` (Ollama + Entra Agent ID side
 ## Prerequisites (verify BEFORE running anything)
 
 1. **Entra role** on signing-in user — one of: `Global Administrator`, `Agent ID Administrator`, `Agent ID Developer`. See [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md).
-2. **Tooling**: `az` ≥ 2.60, `pwsh` 7.4+, `Microsoft.Graph.*` 2.35+, `docker buildx` for `linux/amd64`.
+2. **Tooling**: `az` ≥ 2.60, `pwsh` 7.4+, `Microsoft.Graph.*` 2.35+ (install: `Install-Module Microsoft.Graph.Authentication, Microsoft.Graph.Beta.Applications -Scope CurrentUser`), and one of: `docker buildx` for `linux/amd64` **OR** `az acr build` (no local Docker needed — see Step 4).
 3. **Tenant-confirmed preflight** — ALWAYS confirm tenant ID + subscription ID with the user before any `az` command that mutates resources.
 4. **Entra Agent ID base objects** exist — Blueprint, Agent Identity, Client SPA. If not, run the [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md) skill first.
+
+> [!NOTE]
+> **Windows / PowerShell users:** This skill's scripts and orchestrator are bash. If running from PowerShell without WSL or Git Bash:
+> - `source file` → `. file` or set `$env:VAR` individually
+> - `envsubst` → PowerShell `-replace` operators or `(Get-Content template) -replace '\$\{VAR\}', $value`
+> - `bash script.sh` → translate each `az` / `pwsh` command into the PowerShell session directly
+> - `docker buildx build --push` → `az acr build` for `llm-agent` and `weather-api` (but **not** for baked Ollama — see Step 4)
+> - `az ad app update --set spa='{...}'` may fail with JSON escaping — use `az rest --method PATCH` instead (see Step 6)
 
 ## SKU decisions — ask the user first
 
@@ -43,6 +51,7 @@ Before running any `az` command that provisions resources, confirm each SKU choi
 | `MIN_REPLICAS` / `MAX_REPLICAS` | counts | `1` / `1` | `min=0` = model reloads into RAM on every cold start |
 | `OLLAMA_MODEL` | `qwen2.5:1.5b` / `qwen2.5:7b` / `llama3.2:1b` | `qwen2.5:1.5b` | 7B model on Consumption times out ACA ingress |
 | `OLLAMA_IMAGE_STRATEGY` | `baked` / `runtime-pull` | `baked` | `runtime-pull` = 30 s first-request delay |
+| `OLLAMA_CPU` / `OLLAMA_MEMORY` | see model-to-sizing table | `0.75` / `1.5Gi` | Undersized memory → Ollama OOM. **`qwen2.5:3b` needs 2.5 Gi (requires Dedicated-D4+)**. See [sku-sizing.md §7](./references/sku-sizing.md). |
 
 **When invoking this skill, explicitly state the defaults to the user and ask them to confirm or override — do not assume.**
 
@@ -50,7 +59,7 @@ Before running any `az` command that provisions resources, confirm each SKU choi
 
 ### Step 0 — Confirm account and populate variables
 
-Ask the user to confirm: tenant ID, subscription ID, SKU choices, Ollama model. Then:
+Ask the user to confirm: tenant ID, subscription ID, **resource group name**, **location**, SKU choices (including `OLLAMA_CPU` / `OLLAMA_MEMORY` — match to model), Ollama model. Then:
 
 ```bash
 cp .claude/skills/deploy-agent-aca-dev/scripts/deploy-vars.sh.template /tmp/deploy-vars.sh
@@ -62,6 +71,9 @@ az login --tenant "$TENANT_ID" && az account set --subscription "$SUBSCRIPTION_I
 ### Step 1 — Create Entra objects (Blueprint, Agent, Client SPA)
 
 Delegate to [entra-agent-id-setup](../entra-agent-id-setup/SKILL.md). Capture `BLUEPRINT_APP_ID`, `AGENT_CLIENT_ID`, `CLIENT_SPA_APP_ID` into `/tmp/deploy-vars.sh`.
+
+> [!WARNING]
+> Run `Connect-MgGraph` in an **interactive pwsh session**, not via `pwsh -Command "Connect-MgGraph ..."` subshell. The WAM authentication popup hides behind other windows in a subshell and silently times out.
 
 Configure the Blueprint for OBO using the ACA-compatible PowerShell script:
 
@@ -77,6 +89,10 @@ pwsh -NoProfile -File .claude/skills/deploy-agent-aca-dev/scripts/setup-obo-blue
 
 See tutorial [§6](../../../sidecar/dev/deploy-local-llm-agent-sidecar-container-apps.md#6-phase-2--create-the-azure-infrastructure). Uses SKU variables. Capture `MI_OBJECT_ID` and `APP_FQDN`, append to `/tmp/deploy-vars.sh`. Grant `AcrPull` to the MI.
 
+> [!NOTE]
+> Adding a **Dedicated-D4 workload profile** can take **20+ minutes** to provision. This is normal — do not cancel.
+> If Azure Policy enforces tags on resource groups (e.g., `Owner`, `MonthlyCost`), add them during `az group create` or use a pre-existing RG.
+
 ### Step 3 — Federate MI to Blueprint (only federation chain)
 
 Single Graph call — see tutorial [§7](../../../sidecar/dev/deploy-local-llm-agent-sidecar-container-apps.md#7-phase-3--federate-the-managed-identity-to-the-blueprint). Subject = `$MI_OBJECT_ID`, audience = `api://AzureADTokenExchange`.
@@ -87,7 +103,26 @@ Single Graph call — see tutorial [§7](../../../sidecar/dev/deploy-local-llm-a
 
 Tutorial [§8](../../../sidecar/dev/deploy-local-llm-agent-sidecar-container-apps.md#8-phase-4--build-and-push-container-images). Three images: `llm-agent`, `weather-api`, `ollama` (baked) — or two if using `runtime-pull`.
 
-If `OLLAMA_IMAGE_STRATEGY=baked`:
+**Option A — Local Docker (`docker buildx`):**
+
+Requires Docker Desktop running. Works for all images including baked Ollama.
+
+**Option B — Remote build (`az acr build`):**
+
+No Docker Desktop needed. Works for `llm-agent` and `weather-api` only.
+
+```bash
+az acr build --registry "$ACR_NAME" --image agent-id-dev/llm-agent:1.0.0 --platform linux/amd64 sidecar/dev/
+az acr build --registry "$ACR_NAME" --image agent-id-dev/weather-api:1.0.0 --platform linux/amd64 sidecar/weather-api/
+```
+
+> [!NOTE]
+> `UnicodeEncodeError: 'charmap' codec can't encode characters` from `az acr build` on Windows is **cosmetic** (colorama/cp1252 encoding). The build succeeds — ignore the error.
+
+> [!IMPORTANT]
+> **Baked Ollama images cannot be built via `az acr build`** — the `RUN ollama serve & ollama pull ...` step requires a running Docker daemon that ACR Build does not provide. The image silently fails to appear in ACR. If Docker Desktop is unavailable, switch to `OLLAMA_IMAGE_STRATEGY=runtime-pull`.
+
+If `OLLAMA_IMAGE_STRATEGY=baked` (Option A only):
 
 ```bash
 bash .claude/skills/deploy-agent-aca-dev/scripts/build-ollama-image.sh
@@ -100,11 +135,22 @@ envsubst < .claude/skills/deploy-agent-aca-dev/scripts/containerapp.yaml.templat
 az containerapp update -g "$RG" -n "$APP_NAME" --yaml /tmp/containerapp.yaml
 ```
 
-### Step 6 — Post-deploy manual wiring (REQUIRED)
+### Step 6 — Post-deploy wiring (REQUIRED — execute immediately after Step 5)
+
+> [!IMPORTANT]
+> The AI agent **MUST** execute both sub-steps below. Do NOT skip or leave for the user. These are automatable — `APP_FQDN` is known from Step 2, and all app IDs are known from Step 1.
 
 Two things that cannot be done before deploy:
 
 1. **Add deployed SPA redirect URI** — `bash .claude/skills/deploy-agent-aca-dev/scripts/add-spa-redirect-uri.sh`
+
+   > [!WARNING]
+   > On PowerShell, `az ad app update --set spa='{...}'` fails with `Property spa in payload has a value that does not match schema` due to JSON escaping. Use this workaround instead:
+   > ```powershell
+   > $body = @{ spa = @{ redirectUris = @("http://localhost:3003", "https://$env:APP_FQDN/") } } | ConvertTo-Json -Depth 3
+   > az rest --method PATCH --url "https://graph.microsoft.com/v1.0/applications(appId='$env:CLIENT_SPA_APP_ID')" --body $body --headers "Content-Type=application/json"
+   > ```
+
 2. **Grant Agent → Graph delegated `User.Read`** (fixes `AADSTS65001`):
 
    ```bash
@@ -137,6 +183,7 @@ Persisted in `/tmp/deploy-vars.sh`:
 | `TENANT_ID`, `SUBSCRIPTION_ID` | User |
 | `ACR_SKU`, `ACA_WORKLOAD_PROFILE`, `LOGS_DESTINATION`, `MIN_REPLICAS`, `MAX_REPLICAS` | User (SKU decisions) |
 | `OLLAMA_MODEL`, `OLLAMA_IMAGE_STRATEGY` | User |
+| `OLLAMA_CPU`, `OLLAMA_MEMORY` | User (match to model — see [sku-sizing.md §7](./references/sku-sizing.md)) |
 | `BLUEPRINT_APP_ID`, `AGENT_CLIENT_ID`, `CLIENT_SPA_APP_ID` | Step 1 |
 | `MI_OBJECT_ID`, `APP_FQDN` | Step 2 |
 

--- a/.claude/skills/deploy-agent-aca-dev/references/ollama-on-aca.md
+++ b/.claude/skills/deploy-agent-aca-dev/references/ollama-on-aca.md
@@ -22,6 +22,9 @@ ENTRYPOINT ["ollama", "serve"]
 - **Cons:** ACR image size +~1 GB per model; rebuild on model changes
 - **Script:** [`build-ollama-image.sh`](../scripts/build-ollama-image.sh) automates this
 
+> [!IMPORTANT]
+> **The baked strategy requires a local Docker daemon** (Docker Desktop or equivalent). `az acr build` **cannot** build baked Ollama images — the `RUN ollama serve & ollama pull ...` step needs a running daemon inside the builder, which ACR Build does not support. The image silently fails to appear in ACR. If Docker Desktop is unavailable, use **Strategy B (runtime-pull)** instead.
+
 ### Strategy B — `runtime-pull`
 
 Use `docker.io/ollama/ollama:latest` directly. Model pulls on first request.

--- a/.claude/skills/deploy-agent-aca-dev/references/sku-sizing.md
+++ b/.claude/skills/deploy-agent-aca-dev/references/sku-sizing.md
@@ -71,10 +71,16 @@ Cost estimates are approximate USD/month (East US 2, April 2026) and assume `min
 
 ## 7. Container CPU/memory per replica
 
-The tutorial uses total **1.75 vCPU / 3.5 Gi** across four containers (llm-agent 0.5/1, sidecar 0.25/0.5, weather-api 0.25/0.5, ollama 0.75/1.5). Must match a valid ACA consumption combination.
+The fixed containers use: llm-agent 0.5/1Gi, sidecar 0.25/0.5Gi, weather-api 0.25/0.5Gi (total fixed: **1.0 vCPU / 2.0 Gi**). Ollama is parameterized via `OLLAMA_CPU` and `OLLAMA_MEMORY` — choose based on model:
+
+| Model | `OLLAMA_CPU` | `OLLAMA_MEMORY` | Total (4 containers) | Minimum workload profile |
+|---|---|---|---|---|
+| `qwen2.5:1.5b` / `llama3.2:1b` | `0.75` | `1.5Gi` | 1.75 vCPU / 3.5 Gi | Consumption |
+| `qwen2.5:3b` | `1.0` | `2.5Gi` | 2.0 vCPU / 5.0 Gi | **Dedicated-D4** (exceeds Consumption 4 Gi limit) |
+| `qwen2.5:7b` | `2.0` | `6Gi` | 3.0 vCPU / 8.5 Gi | **Dedicated-D4+** or GPU |
 
 > **[!WARNING] Silent failure mode**
-> If you upsize Ollama to 2 Gi for a 3B model without recomputing totals, the manifest will be rejected at deploy time. Check against [ACA resource allocation](https://learn.microsoft.com/en-us/azure/container-apps/containers).
+> If the total memory exceeds the workload profile limit, the manifest will be rejected at deploy time. `qwen2.5:3b` and larger **cannot run on Consumption** — they require Dedicated-D4 or higher. Check against [ACA resource allocation](https://learn.microsoft.com/en-us/azure/container-apps/containers).
 
 ## Recommended demo defaults (what the orchestrator enforces)
 
@@ -87,5 +93,7 @@ The tutorial uses total **1.75 vCPU / 3.5 Gi** across four containers (llm-agent
 | `MAX_REPLICAS` | `1` |
 | `OLLAMA_MODEL` | `qwen2.5:1.5b` |
 | `OLLAMA_IMAGE_STRATEGY` | `baked` |
+| `OLLAMA_CPU` | `0.75` |
+| `OLLAMA_MEMORY` | `1.5Gi` |
 
 The orchestrator **requires all of these to be set explicitly** — it fails with a clear error if any is missing, so AI agents don't silently pick defaults.

--- a/.claude/skills/deploy-agent-aca-dev/references/troubleshooting.md
+++ b/.claude/skills/deploy-agent-aca-dev/references/troubleshooting.md
@@ -35,3 +35,16 @@ az containerapp logs show -g "$RG" -n "$APP_NAME" --container ollama --tail 50
 # Tail sidecar logs (for Entra auth errors)
 az containerapp logs show -g "$RG" -n "$APP_NAME" --container sidecar --tail 50
 ```
+
+## Additional issues (from field testing)
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| Baked Ollama image silently fails to appear in ACR after `az acr build` | ACR Build cannot run `ollama serve` during Docker build — daemon silently fails | Use local `docker buildx build --push` (requires Docker Desktop), or switch to `runtime-pull` strategy |
+| `Connect-MgGraph` times out or `User canceled authentication` from `pwsh -Command` subshell | WAM authentication popup hidden behind other windows in subshell | Run `Connect-MgGraph` in an interactive `pwsh` session, not via `pwsh -Command "..."` |
+| `WARNING: Missing required scopes: AgentIdentityBlueprint.DeleteRestore.All, AgentIdentity.DeleteRestore.All` | Skill’s `Connect-MgGraph` example listed 8 scopes but `EntraAgentID-Functions.ps1` validates 10 | Reconnect with all 10 scopes — see `entra-agent-id-setup/SKILL.md` Step 1 |
+| `Property spa in payload has a value that does not match schema` from `az ad app update --set spa='{...}'` | PowerShell JSON escaping mangles the payload | Use `az rest --method PATCH --url "https://graph.microsoft.com/v1.0/applications(appId='$CLIENT_SPA_APP_ID')"` with PowerShell-native JSON |
+| `UnicodeEncodeError: 'charmap' codec can't encode characters` from `az acr build` on Windows | colorama/cp1252 encoding mismatch | Cosmetic — ignore. The build succeeds. |
+| Dedicated-D4 workload profile takes 20+ minutes to provision | Normal Azure provisioning time for dedicated profiles | Wait. Do not cancel. |
+| `az group create` denied by Azure Policy (e.g., `SFI-W18-Require Owner tag`) | Org policy requires tags on resource groups | Add required tags: `az group create ... --tags Owner=<you> MonthlyCost=<est>`, or use a pre-existing RG |
+| Ollama container OOMs or performs poorly on 3b model with 1.5 Gi | Model needs more memory than allocated | Set `OLLAMA_MEMORY=2.5Gi` and `OLLAMA_CPU=1.0` for `qwen2.5:3b`. Requires Dedicated-D4+ (exceeds Consumption 4 Gi limit). See [sku-sizing.md §7](./sku-sizing.md). |

--- a/.claude/skills/deploy-agent-aca-dev/scripts/build-ollama-image.sh
+++ b/.claude/skills/deploy-agent-aca-dev/scripts/build-ollama-image.sh
@@ -8,6 +8,19 @@ set -euo pipefail
 : "${ACR_NAME:?}"
 : "${OLLAMA_MODEL:?}"
 
+# The baked strategy requires a local Docker daemon — ollama serve must run during
+# the build to pull the model. az acr build CANNOT do this (daemon silently fails).
+if ! docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker daemon is not running. The baked Ollama strategy requires a local" >&2
+  echo "Docker build (docker buildx). az acr build cannot run 'ollama serve' during build." >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  1. Start Docker Desktop and re-run this script" >&2
+  echo "  2. Switch to runtime-pull strategy: set OLLAMA_IMAGE_STRATEGY=runtime-pull" >&2
+  echo "     and use OLLAMA_IMAGE=docker.io/ollama/ollama:latest (model pulls on first request)" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$( cd "$SCRIPT_DIR/../../../.." && pwd )"
 BUILD_DIR="$REPO_ROOT/sidecar/dev/ollama"

--- a/.claude/skills/deploy-agent-aca-dev/scripts/containerapp.yaml.template
+++ b/.claude/skills/deploy-agent-aca-dev/scripts/containerapp.yaml.template
@@ -51,7 +51,7 @@ properties:
           - { name: VALIDATE_TOKEN_SIGNATURE, value: "true" }
       - name: ollama
         image: ${OLLAMA_IMAGE}
-        resources: { cpu: 0.75, memory: 1.5Gi }
+        resources: { cpu: ${OLLAMA_CPU}, memory: ${OLLAMA_MEMORY} }
         env:
           - { name: OLLAMA_HOST, value: "0.0.0.0:11434" }
     scale:

--- a/.claude/skills/deploy-agent-aca-dev/scripts/deploy-aca-dev.sh
+++ b/.claude/skills/deploy-agent-aca-dev/scripts/deploy-aca-dev.sh
@@ -21,7 +21,7 @@ VARS_FILE="${VARS_FILE:-/tmp/deploy-vars.sh}"
 # Required before we start — including ALL SKU vars (fail hard if missing).
 for var in TENANT_ID SUBSCRIPTION_ID RG LOCATION ACR_NAME APP_NAME \
            ACR_SKU ACA_WORKLOAD_PROFILE LOGS_DESTINATION MIN_REPLICAS MAX_REPLICAS \
-           OLLAMA_MODEL OLLAMA_IMAGE_STRATEGY \
+           OLLAMA_MODEL OLLAMA_IMAGE_STRATEGY OLLAMA_CPU OLLAMA_MEMORY \
            BLUEPRINT_APP_ID AGENT_CLIENT_ID CLIENT_SPA_APP_ID; do
   if [[ -z "${!var:-}" ]]; then
     echo "ERROR: \$$var is not set. Source $VARS_FILE first (see deploy-vars.sh.template)." >&2
@@ -51,6 +51,7 @@ echo "   Workload:      $ACA_WORKLOAD_PROFILE"
 echo "   Logs:          $LOGS_DESTINATION"
 echo "   Replicas:      min=$MIN_REPLICAS max=$MAX_REPLICAS"
 echo "   Ollama model:  $OLLAMA_MODEL  (strategy: $OLLAMA_IMAGE_STRATEGY)"
+echo "   Ollama sizing: $OLLAMA_CPU vCPU / $OLLAMA_MEMORY"
 echo "================================================================"
 
 ### Step 2 — Azure infrastructure + container app skeleton ###

--- a/.claude/skills/deploy-agent-aca-dev/scripts/deploy-vars.sh.template
+++ b/.claude/skills/deploy-agent-aca-dev/scripts/deploy-vars.sh.template
@@ -40,6 +40,14 @@ export MAX_REPLICAS="1"
 #        llama3.2:1b (fastest) | phi3:mini (MS-native)
 export OLLAMA_MODEL="qwen2.5:1.5b"
 
+# Ollama container CPU/memory — MUST match the model choice.
+# The totals across all 4 containers must be a valid ACA consumption combo.
+#   qwen2.5:1.5b / llama3.2:1b  → OLLAMA_CPU=0.75  OLLAMA_MEMORY=1.5Gi  (total: 1.75 vCPU / 3.5 Gi — valid on Consumption)
+#   qwen2.5:3b                  → OLLAMA_CPU=1.0   OLLAMA_MEMORY=2.5Gi  (total: 2.0 vCPU / 5.0 Gi — requires Dedicated-D4+)
+#   qwen2.5:7b                  → OLLAMA_CPU=2.0   OLLAMA_MEMORY=6Gi    (total: 3.0 vCPU / 8.5 Gi — requires Dedicated-D4+ or GPU)
+export OLLAMA_CPU="0.75"
+export OLLAMA_MEMORY="1.5Gi"
+
 # Image strategy: baked (model layered into image, no first-request delay)
 #                 runtime-pull (smaller image, ~30 s hang on first request)
 export OLLAMA_IMAGE_STRATEGY="baked"

--- a/.claude/skills/entra-agent-id-setup/SKILL.md
+++ b/.claude/skills/entra-agent-id-setup/SKILL.md
@@ -25,8 +25,8 @@ End-to-end provisioning of a Microsoft Entra Agent Identity + OBO-capable client
 3. **Tooling**:
    - Azure CLI (`az`) signed in to the target tenant
    - PowerShell 7+ (`pwsh`)
-   - `Microsoft.Graph.Authentication` and `Microsoft.Graph.Beta.Applications` PowerShell modules
-   - Docker Desktop (for sidecar)
+   - `Microsoft.Graph.Authentication` and `Microsoft.Graph.Beta.Applications` PowerShell modules (install: `Install-Module Microsoft.Graph.Authentication, Microsoft.Graph.Beta.Applications -Scope CurrentUser`)
+   - Docker Desktop (only for local docker-compose in Step 4; **not needed** for ACA deployments — see `deploy-agent-aca-dev`)
 4. **MFA**: If the signing-in user was just created, they MUST complete MFA enrollment via browser first (`AADSTS50079`). Password-only `az login -u -p` will fail.
 
 ## Procedure
@@ -35,10 +35,16 @@ End-to-end provisioning of a Microsoft Entra Agent Identity + OBO-capable client
 
 Run the end-to-end workflow. Creates Blueprint app, Blueprint SP, client secret, Agent Identity, and assigns Graph permissions.
 
+> [!WARNING]
+> Run `Connect-MgGraph` in an **interactive pwsh session**, not via `pwsh -Command "Connect-MgGraph ..."` subshell. The WAM authentication popup hides behind other windows in a subshell and silently times out.
+
+> [!NOTE]
+> The scope list below must match what `EntraAgentID-Functions.ps1` validates internally (10 scopes). If you omit any, the script throws `Missing required Microsoft Graph scopes`.
+
 ```powershell
 pwsh
 . /path/to/repo/scripts/EntraAgentID-Functions.ps1
-Connect-MgGraph -Scopes "AgentIdentityBlueprint.AddRemoveCreds.All","AgentIdentityBlueprint.Create","DelegatedPermissionGrant.ReadWrite.All","Application.Read.All","AgentIdentityBlueprintPrincipal.Create","AppRoleAssignment.ReadWrite.All","Directory.Read.All","User.Read" -TenantId <tenant-id>
+Connect-MgGraph -Scopes "AgentIdentityBlueprint.AddRemoveCreds.All","AgentIdentityBlueprint.Create","AgentIdentityBlueprint.DeleteRestore.All","AgentIdentity.DeleteRestore.All","DelegatedPermissionGrant.ReadWrite.All","Application.Read.All","AgentIdentityBlueprintPrincipal.Create","AppRoleAssignment.ReadWrite.All","Directory.Read.All","User.Read" -TenantId <tenant-id>
 
 $r = Start-EntraAgentIDWorkflow -BlueprintName "Demo Blueprint" -AgentName "Weather Agent" -Permissions @("User.Read.All")
 ```

--- a/.claude/skills/entra-agent-id-setup/references/troubleshooting.md
+++ b/.claude/skills/entra-agent-id-setup/references/troubleshooting.md
@@ -28,7 +28,7 @@
 
 **Symptom**: Blueprint secret rejected shortly after creation.
 
-**Cause**: Azure AD propagation delay (~30 s).
+**Cause**: Microsoft Entra ID propagation delay (~30 s).
 
 **Fix**: `New-AgentIdentityBlueprint` already retries up to 10×3s. If still failing, wait 60s and retry the workflow.
 
@@ -70,3 +70,23 @@ Use `Get-DecodedJwtToken -Token $tr` to inspect.
 **Cause**: Microsoft publishes `linux/amd64` only. Docker runs it under Rosetta.
 
 **Fix**: Harmless — the sidecar runs correctly under emulation.
+
+## `Connect-MgGraph` times out in `pwsh -Command` subshell
+
+**Symptom**: `Connect-MgGraph: InteractiveBrowserCredential authentication failed: User canceled authentication.` when run via `pwsh -Command "Connect-MgGraph ..."` subshell.
+
+**Cause**: WAM authentication popup opens behind other windows in a subshell and the user never sees it, so it times out.
+
+**Fix**: Run `Connect-MgGraph` in an **interactive** `pwsh` session. Do not wrap it in `pwsh -Command "..."` or `pwsh -c "..."`.
+
+## Missing Graph scopes from `Start-EntraAgentIDWorkflow`
+
+**Symptom**: `WARNING: Missing required scopes: AgentIdentityBlueprint.DeleteRestore.All, AgentIdentity.DeleteRestore.All` followed by `throw "Missing required Microsoft Graph scopes."`.
+
+**Cause**: `EntraAgentID-Functions.ps1` validates 10 scopes internally. If you connected with only the 8 scopes from an older version of this skill, the two `DeleteRestore` scopes are missing.
+
+**Fix**: Disconnect and reconnect with all 10 scopes:
+```powershell
+Disconnect-MgGraph
+Connect-MgGraph -Scopes "AgentIdentityBlueprint.AddRemoveCreds.All","AgentIdentityBlueprint.Create","AgentIdentityBlueprint.DeleteRestore.All","AgentIdentity.DeleteRestore.All","DelegatedPermissionGrant.ReadWrite.All","Application.Read.All","AgentIdentityBlueprintPrincipal.Create","AppRoleAssignment.ReadWrite.All","Directory.Read.All","User.Read" -TenantId <tenant-id>
+```


### PR DESCRIPTION
## Summary

13 fixes to deployment skills based on field testing on a fresh tenant (Windows/PowerShell environment).

### Changes by category

**Scope fixes (Fix 1-3)**
- Add 2 missing Graph scopes (`AgentIdentityBlueprint.DeleteRestore.All`, `AgentIdentity.DeleteRestore.All`) to `Connect-MgGraph` examples
- Add `Connect-MgGraph` subshell WAM popup warning
- Add PowerShell module install command to prerequisites

**Ollama memory parameterization (Fix 4)**
- Replace hardcoded `{ cpu: 0.75, memory: 1.5Gi }` with `${OLLAMA_CPU}` / `${OLLAMA_MEMORY}` in containerapp.yaml.template
- Add both vars to deploy-vars.sh.template, deploy-aca-dev.sh validation, SKU table
- Document model-to-sizing (3b needs 2.5Gi → requires Dedicated-D4+)

**Build & platform (Fix 5-8, 13)**
- Add `docker info` guard to build-ollama-image.sh — exits with clear error if Docker unavailable
- Document ACR Build limitation for baked Ollama images
- Add Windows/PowerShell translation notes to prerequisites
- Add `az acr build` as Option B (no Docker Desktop needed for llm-agent, weather-api)
- Add `az rest --method PATCH` workaround for SPA redirect URI on PowerShell
- Docker Desktop no longer listed as hard prerequisite for ACA deployments

**Documentation (Fix 9-12)**
- Add 15 new troubleshooting entries across 3 troubleshooting files
- Add RG/location/suffix to Step 0 confirmation list
- Reword Step 6 from 'manual wiring' to 'execute immediately' (AI agent was skipping it)
- Azure AD → Microsoft Entra ID branding fix

### Files changed (12)
- `.claude/skills/entra-agent-id-setup/SKILL.md`
- `.claude/skills/entra-agent-id-setup/references/troubleshooting.md`
- `.claude/skills/deploy-agent-aca-dev/SKILL.md`
- `.claude/skills/deploy-agent-aca-dev/references/troubleshooting.md`
- `.claude/skills/deploy-agent-aca-dev/references/sku-sizing.md`
- `.claude/skills/deploy-agent-aca-dev/references/ollama-on-aca.md`
- `.claude/skills/deploy-agent-aca-dev/scripts/containerapp.yaml.template`
- `.claude/skills/deploy-agent-aca-dev/scripts/deploy-vars.sh.template`
- `.claude/skills/deploy-agent-aca-dev/scripts/deploy-aca-dev.sh`
- `.claude/skills/deploy-agent-aca-dev/scripts/build-ollama-image.sh`
- `.claude/skills/deploy-agent-aca-aws/SKILL.md`
- `.claude/skills/deploy-agent-aca-aws/references/troubleshooting.md`

### Regression risk
- **Zero risk:** Fixes 1-3, 6-13 are doc-only (callouts, warnings, troubleshooting rows, wording)
- **Low risk:** Fix 5 adds a guard check that exits early; existing Docker Desktop flow unaffected
- **Moderate risk:** Fix 4 adds `OLLAMA_CPU`/`OLLAMA_MEMORY` as required vars — existing callers of deploy-aca-dev.sh without these vars will get a clear error from validation loop